### PR TITLE
[OXT-215] atapi_pt_helper:  various refactoring/cleanup/fixes

### DIFF
--- a/atapi_pt_helper/src/Makefile.am
+++ b/atapi_pt_helper/src/Makefile.am
@@ -34,7 +34,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
-
+CFLAGS = -Wall -Werror
 CPROTO=cproto
 INCLUDES = ${X_CFLAGS}
 

--- a/atapi_pt_helper/src/atapi_pt_helper.c
+++ b/atapi_pt_helper/src/atapi_pt_helper.c
@@ -1,16 +1,17 @@
 /*
+ * Copyright (c) 2015 Assured Information Security, Chris Patterson <pattersonc@ainfosec.com>
  * Copyright (c) 2014 Citrix Systems, Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -19,13 +20,53 @@
 
 #include "project.h"
 
-#define ATAPI_HELPER_DEBUG  0
-#define ATAPI_HELPER_TAG    "atapi_helper:"
-#define DPRINTF(fmt, ...)                                           \
-    do {                                                            \
-        if (ATAPI_HELPER_DEBUG)                                     \
-            fprintf(stderr, ATAPI_HELPER_TAG " %s:%d: " fmt "\n",   \
-                    __FILE__, __LINE__, ##__VA_ARGS__);             \
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/param.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <linux/cdrom.h>
+#include <linux/fd.h>
+#include <linux/fs.h>
+#include <linux/cdrom.h>
+#include <linux/bsg.h>
+#include <scsi/sg.h>
+#include <syslog.h>
+
+#include "atapi_pt_v4v.h"
+
+static int pt_log_level = 0;
+
+/**
+ * PT_LOG: information to always log (errors & important low-volume events)
+ * @param fmt,... printf style arguments
+ */
+#define PT_LOG(fmt, ...)                                           \
+do {                                                               \
+        syslog(LOG_NOTICE, "[%s:%s:%d] (stubdom-%d) " fmt,          \
+               __FILE__, __FUNCTION__, __LINE__, g_hs.stubdom_id,  \
+                 ##__VA_ARGS__);                                   \
+    } while (0)
+
+/**
+ * PT_VERBOSE: verbose level
+ * @param fmt,... printf style arguments
+ */
+#define PT_VERBOSE(fmt, ...)                                             \
+    do {                                                               \
+        if (pt_log_level >= 1)                                       \
+            PT_LOG(fmt, ## __VA_ARGS__);                                  \
+    } while (0)
+
+/**
+ * PT_DEBUG: debug level
+ * @param fmt,... printf style arguments
+ */
+#define PT_DEBUG(fmt, ...)                                             \
+    do {                                                               \
+        if (pt_log_level >= 2)                                       \
+            PT_LOG(fmt, ## __VA_ARGS__);                                  \
     } while (0)
 
 #define V4V_TYPE 'W'
@@ -38,167 +79,34 @@
 
 #define MAX_V4V_MSG_SIZE (V4V_ATAPI_PT_RING_SIZE)
 
-typedef enum v4vcmd
-{
-    ATAPI_PT_OPEN      = 0x00,
-    ATAPI_PT_CLOSE     = 0x01,
-    ATAPI_PT_IOCTL     = 0x02,
-    ATAPI_PT_SET_STATE = 0x03,
-    ATAPI_PT_GET_STATE = 0x04,
-
-    ATAPI_PT_NUMBER_OF_COMMAND
-} ptv4vcmd;
-
-enum block_pt_cmd {
-    BLOCK_PT_CMD_ERROR                   = 0x00,
-    BLOCK_PT_CMD_SET_MEDIA_STATE_UNKNOWN = 0x01,
-    BLOCK_PT_CMD_SET_MEDIA_PRESENT       = 0x02,
-    BLOCK_PT_CMD_SET_MEDIA_ABSENT        = 0x03,
-
-    BLOCK_PT_CMD_GET_LASTMEDIASTATE      = 0x04,
-    BLOCK_PT_CMD_GET_SHM_MEDIASTATE      = 0x05
-};
-
-typedef enum {
-    MEDIA_STATE_UNKNOWN = 0x0,
-    MEDIA_PRESENT = 0x1,
-    MEDIA_ABSENT = 0x2
-} ATAPIPTMediaState;
-
-typedef struct ATAPIPTShm {
-    ATAPIPTMediaState    mediastate;
-} ATAPIPTShm;
-
 #define MAX_ATAPI_PT_DEVICES 6
 typedef struct ATAPIPTDeviceState {
-    char filename[256];
-    int fd;
+    /* device "slot" for indicating device */
+    int device_id;
+    int device_fd;
+    char device_path[256];
+    int device_addr_a;
+    int device_addr_b;
+    int device_addr_c;
+    int device_addr_d;
 
-    uint32_t max_atapi_pt_xfer_len;
-
-    ATAPIPTShm* volatile shm;
-    ATAPIPTMediaState lastmediastate;
+    char lock_file_path[256];
+    int lock_fd;
+    uint32_t lock_state;
 } ATAPIPTDeviceState;
 
 typedef struct ATAPIPTHelperState {
-    int v4vfd;
+    int v4v_fd;
     v4v_addr_t remote_addr;
     v4v_addr_t local_addr;
-
     int stubdom_id;
-
-    uint8_t device_number;
     ATAPIPTDeviceState devices[MAX_ATAPI_PT_DEVICES];
 } ATAPIPTHelperState;
 
-static int helper_get_device_state(ATAPIPTHelperState* hs,
-                                   char const* name, size_t len,
-                                   ATAPIPTDeviceState** ds)
-{
-    int i, j;
+/* global helper state */
+static ATAPIPTHelperState g_hs;
 
-    if (!name || !ds) {
-        return -1;
-    }
-
-    for (i = 0; i < MAX_ATAPI_PT_DEVICES; i++) {
-        if (!strncmp(hs->devices[i].filename, name, len)) {
-            *ds = &hs->devices[i];
-            return i;
-        } else if (hs->devices[i].fd == -1) {
-            i = j;
-        }
-    }
-
-    if (j == MAX_ATAPI_PT_DEVICES) {
-        return -1;
-    }
-
-    *ds = &hs->devices[j];
-
-    memset((*ds)->filename, 0, sizeof ((*ds)->filename));
-    memcpy((*ds)->filename, name, len);
-    (*ds)->fd = -1;
-
-    return j;
-}
-
-static int initialize_helper_state(ATAPIPTHelperState* hs)
-{
-    uint32_t v4v_ring_size = V4V_ATAPI_PT_RING_SIZE;
-
-    hs->v4vfd = v4v_socket(SOCK_DGRAM);
-
-    if (hs->v4vfd == -1) {
-        DPRINTF("unable to create a v4vsocket");
-        return -1;
-    }
-
-    hs->local_addr.port = ATAPI_CDROM_PORT;
-    hs->local_addr.domain = V4V_DOMID_ANY;
-
-    hs->remote_addr.port = V4V_PORT_NONE;
-    hs->remote_addr.domain = hs->stubdom_id;
-
-    ioctl(hs->v4vfd, V4VIOCSETRINGSIZE, &v4v_ring_size);
-    if (v4v_bind(hs->v4vfd, &hs->local_addr, hs->stubdom_id) == -1) {
-        DPRINTF("unable to bind the v4vsocket");
-        v4v_close(hs->v4vfd);
-        return -1;
-    }
-
-    return 0;
-}
-
-static int atapi_pt_open(ATAPIPTHelperState* hs, uint8_t* buf, size_t len)
-{
-    ATAPIPTDeviceState* ds = NULL;
-    int device_id = -1;
-
-    device_id = helper_get_device_state(hs, &buf[1], len - 1, &ds);
-
-    if (ds->fd == -1)
-        ds->fd = open(ds->filename, O_RDWR | O_NONBLOCK);
-
-    if (device_id == -1 || ds->fd == -1) {
-        buf[1] = 'k';
-        buf[2] = 'o';
-        DPRINTF("device state not found for '%s'", &buf[1]);
-    } else {
-        buf[1] = 'o';
-        buf[2] = 'k';
-    }
-
-    buf[3] = device_id;
-
-    DPRINTF("open (%s): send message [%c%c-%d]",
-            ds->filename, buf[1], buf[2], buf[3]);
-    if (v4v_sendto(hs->v4vfd, buf, 4, 0, &hs->remote_addr) != 4) {
-       DPRINTF("unable to send a message to %s", ds->filename);
-       return -1;
-    }
-
-    return 0;
-}
-
-static int atapi_pt_close(ATAPIPTHelperState* hs, uint8_t* buf, size_t len)
-{
-    ATAPIPTDeviceState* ds = NULL;
-    int ret = -1;
-
-    if (buf[1] < MAX_ATAPI_PT_DEVICES) {
-        ds = &hs->devices[buf[1]];
-        if (ds->fd > -1) {
-            close(ds->fd);
-            ds->fd = -1;
-        }
-        ret = 0;
-        DPRINTF("device (%s) closed", ds->filename);
-    }
-
-    return ret;
-}
-
+#if 0
 static void dump_hex(uint8_t* p, size_t len)
 {
   int i, j;
@@ -217,279 +125,603 @@ static void dump_hex(uint8_t* p, size_t len)
     fprintf(stderr, "\n");
   }
 }
+#endif
 
-static int atapi_pt_ioctl(ATAPIPTHelperState* hs, uint8_t* buf, size_t len)
+static int pending_exit = 0;
+
+/**
+ * Time to bail! Will call exit() with exit_code.
+ * @param[in] exit_code
+ */
+static void exit_cleanup(int exit_code)
 {
-    ATAPIPTDeviceState* ds;
-    unsigned long int req;
-    uint32_t reserved_size;
+    int i;
+
+    pending_exit = 1;
+
+    /* close all devices */
+    for (i = 0; i < MAX_ATAPI_PT_DEVICES; i++) {
+        ATAPIPTDeviceState *ds = &g_hs.devices[i];
+        if (ds->device_path[0] == 0) {
+            /* device_path is blank, this slot is empty */
+            continue;
+        }
+        if (ds->device_fd >= 0) {
+            close(ds->device_fd);
+            ds->device_fd = -1;
+        }
+        if (ds->lock_fd >= 0) {
+            close(ds->lock_fd);
+            ds->lock_fd = -1;
+        }
+    }
+
+    /* close v4v channel to stubdom */
+    v4v_close(g_hs.v4v_fd);
+    g_hs.v4v_fd = -1;
+
+    /* close syslog */
+    closelog();
+
+    /* time to bail */
+    exit(exit_code);
+}
+
+/**
+ * Grabs global exclusive lock.
+ * @param[in] ds
+ * @returns 1 if lock held, 0 otherwise
+ */
+static int acquire_global_lock(ATAPIPTDeviceState *ds)
+{
+    struct flock lock = {0};
+
+    if (ds->lock_state == ATAPI_PT_LOCK_STATE_LOCKED_BY_ME) {
+        /* already have lock */
+        return 1;
+    }
+
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_start = 0;
+    lock.l_len = 0;
+
+    if (fcntl(ds->lock_fd, F_SETLK, &lock) == 0) {
+        PT_LOG("locked by me: %s\n", ds->device_path);
+        ds->lock_state = ATAPI_PT_LOCK_STATE_LOCKED_BY_ME;
+        return 1;
+    }
+
+    PT_LOG("locked by other: %s\n", ds->device_path);
+    ds->lock_state = ATAPI_PT_LOCK_STATE_LOCKED_BY_OTHER;
+    return 0;
+}
+
+/**
+ * Releases global exclusive lock.
+ * @param[in] ds
+ */
+static void release_global_lock(ATAPIPTDeviceState *ds)
+{
+    struct flock lock = {0};
+
+    if (ds->lock_state != ATAPI_PT_LOCK_STATE_LOCKED_BY_ME) {
+        /* we don't have the lock, nothing to do */
+        return;
+    }
+
+    lock.l_type = F_UNLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_start = 0;
+    lock.l_len = 0;
+
+    fcntl(ds->lock_fd, F_SETLK, &lock);
+
+    ds->lock_state = ATAPI_PT_LOCK_STATE_UNLOCKED;
+
+    PT_LOG("released lock: %s\n", ds->device_path);
+}
+
+/**
+ * Initializes device state if device not already opened.
+ * @param[in] device_path File path to device (e.g. /dev/bsg/1:0:0:0)
+ * @returns Pointer to device state, otherwise NULL on error.
+ */
+static ATAPIPTDeviceState *init_device_state(ATAPIPTHelperState *hs,
+                                             const char *device_path)
+{
+    ATAPIPTDeviceState *ds = NULL;
+    int i;
+
+    if (!device_path) {
+        return NULL;
+    }
+
+    for (i = 0; i < MAX_ATAPI_PT_DEVICES; i++) {
+        ds = &hs->devices[i];
+        if (ds->device_path[0] == 0) {
+            /* device_path is blank, this slot is free to use */
+            break;
+        }
+        if (strcmp(hs->devices[i].device_path, device_path) == 0) {
+            /* found matching device already open */
+            return ds;
+        }
+    }
+
+    if (i == MAX_ATAPI_PT_DEVICES) {
+        /* no available slots */
+        PT_LOG("error: ran out of slots!\n");
+        return NULL;
+    }
+
+    /* before we register - parse path & make sure it is legit */
+    if (sscanf(device_path, "/dev/bsg/%d:%d:%d:%d", &ds->device_addr_a,
+                                                 &ds->device_addr_b,
+                                                 &ds->device_addr_c,
+                                                 &ds->device_addr_d) != 4) {
+        PT_LOG("error: invalid device path: %s!\n", ds->device_path);
+        return NULL;
+    }
+
+    snprintf(ds->device_path, sizeof(ds->device_path), "/dev/bsg/%d:%d:%d:%d",
+             ds->device_addr_a, ds->device_addr_b,
+             ds->device_addr_c, ds->device_addr_d);
+
+    /* make sure the device path is what we think it is */
+    if (strcmp(device_path, ds->device_path) != 0) {
+        PT_LOG("error: bad path: %s vs %s\n", device_path, ds->device_path);
+        return NULL;
+    }
+
+    /* open descriptor to device */
+    ds->device_fd = open(device_path, O_RDWR | O_NONBLOCK);
+    if (ds->device_fd < 0) {
+        PT_LOG("error: unable to open device path: %s!\n", device_path);
+        return NULL;
+    }
+
+    /* set device id (index into devices) */
+    ds->device_id = i;
+
+    snprintf(ds->lock_file_path, sizeof(ds->lock_file_path),
+          "/var/lock/xen-atapi-pt-lock-%d_%d_%d_%d",
+          ds->device_addr_a,
+          ds->device_addr_b,
+          ds->device_addr_c,
+          ds->device_addr_d);
+
+
+    /* open lock file */
+    ds->lock_fd = open(ds->lock_file_path, O_RDWR | O_CREAT, 0666);
+    if (ds->lock_fd < 0) {
+        PT_LOG("error: unable to open lock file: %s!\n", ds->lock_file_path);
+        close(ds->device_fd);
+        ds->device_fd = -1;
+        return NULL;
+    }
+
+    /* assume unlocked for init - doesn't have to be true */
+    ds->lock_state = ATAPI_PT_LOCK_STATE_UNLOCKED;
+
+    return ds;
+}
+
+/**
+ * Initializes helper state.
+ * @param[in] hs
+ * @returns 0 on succes, otherwise -1.
+ */
+static int init_helper_state(ATAPIPTHelperState *hs)
+{
+    uint32_t v4v_ring_size = V4V_ATAPI_PT_RING_SIZE;
+
+    hs->v4v_fd = v4v_socket(SOCK_DGRAM);
+
+    if (hs->v4v_fd == -1) {
+        PT_LOG("unable to create a v4vsocket");
+        return -1;
+    }
+
+    hs->local_addr.port = ATAPI_CDROM_PORT;
+    hs->local_addr.domain = V4V_DOMID_ANY;
+
+    hs->remote_addr.port = V4V_PORT_NONE;
+    hs->remote_addr.domain = hs->stubdom_id;
+
+    ioctl(hs->v4v_fd, V4VIOCSETRINGSIZE, &v4v_ring_size);
+    if (v4v_bind(hs->v4v_fd, &hs->local_addr, hs->stubdom_id) == -1) {
+        PT_LOG("unable to bind the v4vsocket");
+        v4v_close(hs->v4v_fd);
+        hs->v4v_fd = -1;
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * Sends v4v message to stubdom.
+ * @param[in] hs
+ * @param[in] buf: message to send
+ * @param[in] size: size of buf
+ * @returns true if message sent successfully, false otherwise.
+ */
+static bool pt_v4v_send_message(ATAPIPTHelperState* hs, void *buf, size_t size)
+{
     int ret;
 
-    struct sg_io_v4* cmd;
-    int is_dout;
+    ret = v4v_sendto(hs->v4v_fd, buf, size, 0, &hs->remote_addr);
 
-    if (!(buf[1] < MAX_ATAPI_PT_DEVICES)) {
+    if (ret != size) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Provides pointer to device state from a device id.
+ * @param[in] device_id: Device ID
+ * @returns Pointer to device state if valid device id, NULL otherwise.
+ */
+static ATAPIPTDeviceState * device_id_to_device_state(ATAPIPTHelperState* hs,
+                                                      uint8_t device_id)
+{
+    ATAPIPTDeviceState *ds;
+
+    if (device_id < 0 || device_id >= MAX_ATAPI_PT_DEVICES) {
+        return NULL;
+    }
+
+    ds = &hs->devices[device_id];
+
+    if (ds->device_path[0] == 0) {
+        /* device_path is blank, this slot is invalid */
+        return NULL;
+    }
+
+    return ds;
+}
+
+/**
+ * Handles ATAPI_PTV4V_OPEN command from qemu stubdom.
+ * @param[in] hs: Helper state pointer.
+ * @param[in] buf: Data packet received from qemu.
+ * @param[in] len: Length of data packet received.
+ * @returns 0 on success, -1 on errror.
+ */
+static int atapi_ptv4v_open(ATAPIPTHelperState *hs, uint8_t *buf, size_t len)
+{
+    pt_v4vcmd_open_request_t *request = (pt_v4vcmd_open_request_t *)buf;
+    pt_v4vcmd_open_response_t response;
+    ATAPIPTDeviceState *ds;
+
+    if (len != sizeof(*request)) {
+        PT_LOG("error: mismatch buffer size %d vs %d", len, sizeof(*request));
         return -1;
     }
 
-    ds = &hs->devices[buf[1]];
-    if (ds->fd == -1) {
+    ds = init_device_state(hs, request->device_path);
+    if (!ds) {
+        PT_LOG("error: unable to open device path!\n");
         return -1;
     }
 
-    req  = (buf[2] << 24) & 0xFF000000;
-    req |= (buf[3] << 16) & 0x00FF0000;
-    req |= (buf[4] <<  8) & 0x0000FF00;
-    req |= (buf[5] <<  0) & 0x000000FF;
+    response.cmd = ATAPI_PTV4V_OPEN;
+    response.device_id = ds->device_id;
 
-    switch (req) {
-    case SG_GET_RESERVED_SIZE:
-        ret = ioctl(ds->fd, req, &reserved_size);
-        if (ret == -1) {
-            DPRINTF("SG_IO error %s", strerror(errno));
-            buf[1] = 'k';
-            buf[2] = 'o';
-            len = 3;
-        } else {
-            buf[1] = 'o';
-            buf[2] = 'k';
-            memcpy(&buf[3], &reserved_size, sizeof(reserved_size));
-            DPRINTF("reserved_size = %u", reserved_size);
-            len = 7;
-        }
-        break;
-    case SG_IO:
-        //dump_hex(buf, len);
-        cmd = (struct sg_io_v4*)&buf[6];
-        is_dout = (cmd->dout_xfer_len > 0) ? 1 : 0;
-        cmd->request = &buf[6] + sizeof(struct sg_io_v4);
-        if (is_dout) {
-            cmd->dout_xferp = cmd->request + cmd->request_len;
-        }
-        cmd->response = &buf[6] + sizeof(struct sg_io_v4);
-        if (!is_dout) {
-            cmd->din_xferp = cmd->response + cmd->max_response_len;
-        }
+    PT_LOG("opened %s - id = %d\n", ds->device_path, ds->device_id);
 
-        ret = ioctl(ds->fd, req, cmd);
-        if (ret == -1) {
-            DPRINTF("SG_IO error %s", strerror(errno));
-            buf[1] = 'k';
-            buf[2] = 'o';
-        } else {
-            buf[1] = 'o';
-            buf[2] = 'k';
-        }
-
-        len = 6 + sizeof (struct sg_io_v4) + cmd->max_response_len;
-        if (!is_dout) {
-            len += cmd->din_xfer_len;
-        }
-        break;
-    default:
-        DPRINTF("IOCTL(0x%08x) not supported", req);
-        buf[1] = 'k';
-        buf[2] = 'o';
-        len = 3;
-        break;
-    }
-
-    if (v4v_sendto(hs->v4vfd, buf, len, 0, &hs->remote_addr) != len) {
-       DPRINTF("unable to send a message to %s", ds->filename);
-       return -1;
+    if (!pt_v4v_send_message(hs, &response, sizeof(response))) {
+        PT_LOG("error: failed to send a message to %s", ds->device_path);
+        return -1;
     }
 
     return 0;
 }
 
-static int atapi_pt_set_state(ATAPIPTHelperState* hs, uint8_t* buf, size_t len)
+/**
+ * Handles ATAPI_PTV4V_ACQUIRE_LOCK command from qemu stubdom.
+ * @param[in] hs: Helper state pointer.
+ * @param[in] buf: Data packet received from qemu.
+ * @param[in] len: Length of data packet received.
+ * @returns 0 on success, -1 on errror.
+ */
+static int atapi_ptv4v_acquire_lock(ATAPIPTHelperState* hs, uint8_t *buf,
+                                    size_t len)
 {
-    ATAPIPTDeviceState* ds = NULL;
-    uint8_t cmd;
+    pt_v4vcmd_acquire_lock_request_t *request;
+    pt_v4vcmd_acquire_lock_response_t response;
+    ATAPIPTDeviceState *ds;
 
-    if (!(buf[1] < MAX_ATAPI_PT_DEVICES)) {
+    request = (pt_v4vcmd_acquire_lock_request_t *)buf;
+
+    if (len != sizeof(*request)) {
+        PT_LOG("error: mismatch buffer size %d vs %d", len, sizeof(*request));
         return -1;
     }
 
-    ds = &hs->devices[buf[1]];
-    if (ds->fd == -1) {
+    ds = device_id_to_device_state(hs, request->device_id);
+    if (ds == NULL) {
+        PT_LOG("error: invalid device id!\n");
         return -1;
     }
-    cmd = buf[2];
-    buf[1] = 'o';
-    buf[2] = 'k';
-    switch (cmd) {
-    case BLOCK_PT_CMD_SET_MEDIA_STATE_UNKNOWN:
-        ds->shm->mediastate = MEDIA_STATE_UNKNOWN;
-        break;
-    case BLOCK_PT_CMD_SET_MEDIA_PRESENT:
-        ds->shm->mediastate = MEDIA_PRESENT;
-        ds->lastmediastate = MEDIA_PRESENT;
-        break;
-    case BLOCK_PT_CMD_SET_MEDIA_ABSENT:
-        /* TODO: No media, remove exclusivity lock */
-        ds->shm->mediastate = MEDIA_ABSENT;
-        ds->lastmediastate = MEDIA_ABSENT;
-        break;
-    case BLOCK_PT_CMD_ERROR:
-    default:
-        buf[1] = 'k';
-        buf[2] = 'o';
-        break;
-    }
 
-    if (v4v_sendto(hs->v4vfd, buf, 3, 0, &hs->remote_addr) != 3) {
-       DPRINTF("unable to send a message to %s", ds->filename);
-       return -1;
+    acquire_global_lock(ds);
+
+    response.cmd = ATAPI_PTV4V_ACQUIRE_LOCK;
+    response.device_id = ds->device_id;
+    response.lock_state = ds->lock_state;
+
+    PT_LOG("acquire lock for %s = %d\n", ds->device_path, ds->lock_state);
+
+    if (!pt_v4v_send_message(hs, &response, sizeof(response))) {
+        PT_LOG("error: failed to send a message to %s", ds->device_path);
+        return -1;
     }
 
     return 0;
 }
 
-static int atapi_pt_get_state(ATAPIPTHelperState* hs, uint8_t* buf, size_t len)
+/**
+ * Handles ATAPI_PTV4V_RELEASE_LOCK command from qemu stubdom.
+ * @param[in] hs: Helper state pointer.
+ * @param[in] buf: Data packet received from qemu.
+ * @param[in] len: Length of data packet received.
+ * @returns 0 on success, -1 on errror.
+ */
+static int atapi_ptv4v_release_lock(ATAPIPTHelperState* hs, uint8_t *buf,
+                                    size_t len)
 {
-    ATAPIPTDeviceState* ds = NULL;
-    uint8_t cmd;
+    pt_v4vcmd_release_lock_request_t *request;
+    ATAPIPTDeviceState *ds;
 
-    if (!(buf[1] < MAX_ATAPI_PT_DEVICES)) {
+    request = (pt_v4vcmd_release_lock_request_t *)buf;
+
+    if (len != sizeof(*request)) {
+        PT_LOG("error: mismatch buffer size %d vs %d", len, sizeof(*request));
         return -1;
     }
 
-    ds = &hs->devices[buf[1]];
-    if (ds->fd == -1) {
+    ds = device_id_to_device_state(hs, request->device_id);
+    if (ds == NULL) {
+        PT_LOG("error: invalid device id!\n");
         return -1;
     }
-    cmd = buf[2];
-    buf[1] = 'o';
-    buf[2] = 'k';
-    switch (cmd) {
-    case BLOCK_PT_CMD_GET_LASTMEDIASTATE:
-        buf[3] = ds->lastmediastate;
-        break;
-    case BLOCK_PT_CMD_GET_SHM_MEDIASTATE:
-        buf[3] = ds->shm->mediastate;
-        break;
-    case BLOCK_PT_CMD_ERROR:
-    default:
-        buf[1] = 'k';
-        buf[2] = 'o';
-        break;
+
+    release_global_lock(ds);
+
+    PT_LOG("release lock for %s = %d\n", ds->device_path, ds->lock_state);
+    return 0;
+}
+
+/**
+ * Handles ATAPI_PTV4V_SG_GET_RESERVED_SIZE command from qemu stubdom.
+ * @param[in] hs: Helper state pointer.
+ * @param[in] buf: Data packet received from qemu.
+ * @param[in] len: Length of data packet received.
+ * @returns 0 on success, -1 on errror.
+ */
+static int atapi_ptv4v_sg_get_reserved_size(ATAPIPTHelperState* hs,
+                                            uint8_t *buf, size_t len)
+{
+    pt_v4vcmd_sg_get_reserved_size_request_t *request;
+    pt_v4vcmd_sg_get_reserved_size_response_t response;
+    ATAPIPTDeviceState *ds;
+
+    request = (pt_v4vcmd_sg_get_reserved_size_request_t *)buf;
+
+    if (len != sizeof(*request)) {
+        PT_LOG("error: mismatch buffer size %d vs %d", len, sizeof(*request));
+        return -1;
     }
 
-    if (v4v_sendto(hs->v4vfd, buf, 3, 0, &hs->remote_addr) != 3) {
-       DPRINTF("unable to send a message to %s", ds->filename);
-       return -1;
+    ds = device_id_to_device_state(hs, request->device_id);
+    if (ds == NULL) {
+        PT_LOG("error: invalid device id!\n");
+        return -1;
+    }
+
+    response.cmd = ATAPI_PTV4V_SG_GET_RESERVED_SIZE;
+    response.device_id = ds->device_id;
+
+    if (ioctl(ds->device_fd, SG_GET_RESERVED_SIZE, &response.size) < 0) {
+        PT_LOG("SG_GET_RESERVED_SIZE error %s - %s",
+                ds->device_path, strerror(errno));
+        return -1;
+    }
+
+    PT_LOG("sg get reserved size for %s = %d\n", ds->device_path,
+            (int)response.size);
+
+    if (!pt_v4v_send_message(hs, &response, sizeof(response))) {
+        PT_LOG("error: failed to send a message to %s", ds->device_path);
+        return -1;
     }
 
     return 0;
 }
 
-static const struct {
-    char const* name;
-    int (*cmd)(ATAPIPTHelperState* hs, uint8_t* buf, size_t len);
-} v4v_atapi_cmds[ATAPI_PT_NUMBER_OF_COMMAND] = {
-    [ATAPI_PT_OPEN] = {
-        .name = "ATAPI_PT_OPEN",
-        .cmd = atapi_pt_open
-    },
-    [ATAPI_PT_CLOSE] = {
-        .name = "ATAPI_PT_CLOSE",
-        .cmd = atapi_pt_close
-    },
-    [ATAPI_PT_IOCTL] = {
-        .name = "ATAPI_PT_IOCTL",
-        .cmd = atapi_pt_ioctl
-    },
-    [ATAPI_PT_SET_STATE] = {
-        .name = "ATAPI_PT_SET_STATE",
-        .cmd = atapi_pt_set_state
-    },
-    [ATAPI_PT_GET_STATE] = {
-        .name = "ATAPI_PT_GET_STATE",
-        .cmd = atapi_pt_get_state
-    }
-};
-
-static void close_helper_state(ATAPIPTHelperState* hs)
+/**
+ * Handles ATAPI_PTV4V_SG_IO command from qemu stubdom.
+ * @param[in] hs: Helper state pointer.
+ * @param[in] buf: Data packet received from qemu.
+ * @param[in] len: Length of data packet received.
+ * @returns 0 on success, -1 on errror.
+ */
+static int atapi_ptv4v_sg_io(ATAPIPTHelperState* hs, uint8_t *buf, size_t len)
 {
-    uint8_t buf[2];
+    pt_v4vcmd_sg_io_request_t *request = (pt_v4vcmd_sg_io_request_t *)buf;
 
-    if (hs->v4vfd > -1) {
-        v4v_close(hs->v4vfd);
+    /* TODO: MAX_V4V_MSG_SIZE :( - din/dout data needs be contrained properly */
+    uint8_t buf_out[MAX_V4V_MSG_SIZE] = {0, };
+    pt_v4vcmd_sg_io_response_t *response;
+
+    ATAPIPTDeviceState *ds;
+    struct sg_io_v4 cmd;
+
+    response = (pt_v4vcmd_sg_io_response_t *)buf_out;
+
+    /* len must at least be size of request */
+    if (len < sizeof(*request)) {
+        PT_LOG("error: bad buffer size %d vs %d", len, sizeof(*request));
+        return -1;
     }
 
-    for (buf[1] = 0; buf[1] < MAX_ATAPI_PT_DEVICES; buf[1]++) {
-        atapi_pt_close(hs, buf, 2);
+    /* now validate true length using data len in request */
+    if (len != sizeof(*request) + request->dout_data_len) {
+        PT_LOG("error: buffer size %d vs %d", len,
+                sizeof(*request) + request->dout_data_len);
+        return -1;
     }
 
-    memset(hs, 0, sizeof (ATAPIPTHelperState));
+    ds = device_id_to_device_state(hs, request->device_id);
+    if (ds == NULL) {
+        PT_LOG("error: invalid device id!\n");
+        return -1;
+    }
+
+    /* setup sgio cmd struct with incoming copy */
+    memcpy(&cmd, &request->sgio, sizeof(cmd));
+
+    /* init the sgio pointers */
+    cmd.request = (uintptr_t)&request->request_data[0];
+    cmd.response = (uintptr_t)&response->sense_data[0];
+
+    if (cmd.dout_xfer_len > 0) {
+        cmd.dout_xferp = (uintptr_t)&request->dout_data[0];
+        cmd.din_xferp = (uintptr_t)NULL;
+    } else {
+        cmd.dout_xferp = (uintptr_t)NULL;
+        cmd.din_xferp = (uintptr_t)&response->din_data[0];
+    }
+
+    /* validate sense ("response") data len */
+    if (cmd.max_response_len > sizeof(response->sense_data)) {
+        PT_LOG("error: invalid max_response_len! %d\n", cmd.max_response_len);
+        return -1;
+    }
+
+    /* make sure din_xfer_len will fit in response */
+    if (sizeof(buf_out) < sizeof(response) + cmd.din_xfer_len) {
+        PT_LOG("error: bad din_xfer_len %d", cmd.din_xfer_len);
+        return -1;
+    }
+
+    /* fire off ioctl */
+    if (ioctl(ds->device_fd, SG_IO, &cmd) < 0) {
+        PT_LOG("SG_IO error %s - %s", ds->device_path, strerror(errno));
+        return -1;
+    }
+
+    PT_DEBUG("SG_IO complete %s\n", ds->device_path);
+
+    /* scrub outgoing pointers */
+    cmd.request = 0;
+    cmd.response = 0;
+    cmd.dout_xferp = 0;
+    cmd.din_xferp = 0;
+
+    /* populate outgoing packet */
+    response->cmd = ATAPI_PTV4V_SG_IO;
+    response->device_id = ds->device_id;
+    memcpy(&response->sgio, &cmd, sizeof(response->sgio));
+    response->din_data_len = cmd.din_xfer_len;
+    /* response.sense_data is populated by SG_IO */
+    /* response.din_data is populated by SG_IO */
+
+    len = sizeof(*response) + cmd.din_xfer_len;
+    if (!pt_v4v_send_message(hs, response, len)) {
+       PT_LOG("error: failed to send a message to %s", ds->device_path);
+       return -1;
+    }
+
+    return 0;
 }
-
-static ATAPIPTHelperState* hs_g;
 
 static void signal_handler(int sig)
 {
-    DPRINTF("handle signal %d", sig);
-
-    close_helper_state(hs_g);
-    exit(0);
+    PT_LOG("handle signal %d", sig);
+    exit_cleanup(0);
 }
 
 int main(int const argc, char const* const* argv)
 {
-    int ret = 1;
-    ATAPIPTHelperState hs;
-    uint8_t io_buf[MAX_V4V_MSG_SIZE];
-    uint8_t cmdID;
-    int continue_listen = 1;
+    openlog(NULL, LOG_NDELAY, LOG_DAEMON);
 
-    DPRINTF("START");
-    memset(&hs, 0, sizeof (ATAPIPTHelperState));
+    PT_LOG("starting %s\n", argv[0]);
+
+    memset(&g_hs, 0, sizeof(g_hs));
 
     if (argc != 3) {
-        DPRINTF("wrong syntax: should be %s <target_id> <stubdom_id>", argv[0]);
-        goto main_exit;
+        PT_LOG("wrong syntax: should be %s <target_id> <stubdom_id>", argv[0]);
+        return -1;
     }
 
-    hs.stubdom_id = atoi(argv[2]);
+    g_hs.stubdom_id = atoi(argv[2]);
 
-    if (!(hs.stubdom_id > 0)) {
-        DPRINTF("wrong stubdom ID (%d) should be greaten than 0", hs.stubdom_id);
-        goto main_exit;
-    }
-
-    ret = initialize_helper_state(&hs);
-    if  (ret) {
-        continue_listen = 0;
+    if (g_hs.stubdom_id <= 0) {
+        PT_LOG("bad stubdom id (%d)", g_hs.stubdom_id);
+        return -1;
     }
 
     signal(SIGINT, signal_handler);
-    hs_g = &hs;
 
-    while (continue_listen) {
-        DPRINTF("wait for command from stubdom (%d)", hs.stubdom_id);
-        memset(io_buf, 0, sizeof (io_buf));
-        ret = v4v_recvfrom(hs.v4vfd, io_buf, sizeof (io_buf),
-                           0, &hs.remote_addr);
+    if (init_helper_state(&g_hs) != 0) {
+        PT_LOG("failed to init helper!\n");
+        return -1;
+    }
 
-        cmdID = io_buf[0];
-        DPRINTF("receive request for command ID (%d)", cmdID);
-        if (cmdID < ATAPI_PT_NUMBER_OF_COMMAND) {
-            DPRINTF("  command: %s",
-                    v4v_atapi_cmds[cmdID].name);
-            ret = v4v_atapi_cmds[cmdID].cmd(&hs, io_buf, ret);
-            DPRINTF("  command %s return code %d",
-                    v4v_atapi_cmds[cmdID].name, ret);
-        } else {
-            ret = 1;
-            continue_listen = 0;
-            DPRINTF("Command not supported: 0x%02x", io_buf[0]);
+    while (!pending_exit) {
+        int ret;
+        uint8_t io_buf[MAX_V4V_MSG_SIZE] = {0,};
+
+        PT_DEBUG("wait for command from stubdom (%d)", g_hs.stubdom_id);
+
+        /* updates global remote_addr on per-packet basis */
+        ret = v4v_recvfrom(g_hs.v4v_fd, io_buf, sizeof(io_buf),
+                           0, &g_hs.remote_addr);
+
+        if (ret < 0) {
+            PT_LOG("v4v_recvfrom failed!\n");
+            break;
+        }
+
+        switch (io_buf[0]) {
+            case ATAPI_PTV4V_OPEN:
+                PT_LOG("ATAPI_PTV4V_OPEN\n");
+                ret = atapi_ptv4v_open(&g_hs, io_buf, ret);
+                break;
+            case ATAPI_PTV4V_SG_IO:
+                PT_DEBUG("ATAPI_PTV4V_SG_IO\n");
+                ret = atapi_ptv4v_sg_io(&g_hs, io_buf, ret);
+                break;
+            case ATAPI_PTV4V_SG_GET_RESERVED_SIZE:
+                PT_LOG("ATAPI_PTV4V_SG_GET_RESERVED_SIZE\n");
+                ret = atapi_ptv4v_sg_get_reserved_size(&g_hs, io_buf, ret);
+                break;
+            case ATAPI_PTV4V_ACQUIRE_LOCK:
+                PT_LOG("ATAPI_PTV4V_ACQUIRE_LOCK\n");
+                ret = atapi_ptv4v_acquire_lock(&g_hs, io_buf, ret);
+                break;
+            case ATAPI_PTV4V_RELEASE_LOCK:
+                PT_LOG("ATAPI_PTV4V_RELEASE_LOCK\n");
+                ret = atapi_ptv4v_release_lock(&g_hs, io_buf, ret);
+                break;
+            default:
+                PT_LOG("bad command = %d", io_buf[0]);
+                ret = -1;
+                break;
+        }
+
+        if (ret < 0) {
+            PT_LOG("command failed!\n");
+            break;
         }
     }
 
-    DPRINTF("Exit");
-    close_helper_state(&hs);
-
-main_exit:
-    return ret;
+    PT_LOG("exiting...\n");
+    exit_cleanup(0);
+    return 0;
 }

--- a/atapi_pt_helper/src/atapi_pt_v4v.h
+++ b/atapi_pt_helper/src/atapi_pt_v4v.h
@@ -1,0 +1,93 @@
+/*
+ *
+ * Copyright (C) 2015 Assured Information Security, Chris Patterson <pattersonc@ainfosec.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef _ATAPI_PT_V4V_H_
+#define _ATAPI_PT_V4V_H_
+
+typedef enum {
+    ATAPI_PT_LOCK_STATE_UNLOCKED         = 0x00,
+    ATAPI_PT_LOCK_STATE_LOCKED_BY_ME     = 0x01,
+    ATAPI_PT_LOCK_STATE_LOCKED_BY_OTHER  = 0x02,
+} atapi_pt_lock_state_t;
+
+typedef enum {
+    ATAPI_PTV4V_OPEN                     = 0x00,
+    ATAPI_PTV4V_SG_IO                    = 0x01,
+    ATAPI_PTV4V_SG_GET_RESERVED_SIZE     = 0x02,
+    ATAPI_PTV4V_ACQUIRE_LOCK             = 0x03,
+    ATAPI_PTV4V_RELEASE_LOCK             = 0x04,
+} atapi_ptv4v_cmd_t;
+
+typedef struct {
+    uint8_t cmd; /* ATAPI_PTV4V_OPEN */
+    uint8_t device_id;
+    char device_path[256];
+} __attribute__((packed)) pt_v4vcmd_open_request_t;
+
+typedef struct {
+    uint8_t cmd; /* ATAPI_PTV4V_OPEN */
+    uint8_t device_id;
+} __attribute__((packed)) pt_v4vcmd_open_response_t;
+
+typedef struct {
+    uint8_t cmd; /* ATAPI_PTV4V_ACQUIRE_LOCK */
+    uint8_t device_id;
+} __attribute__((packed)) pt_v4vcmd_acquire_lock_request_t;
+
+typedef struct {
+    uint8_t cmd; /* ATAPI_PTV4V_ACQUIRE_LOCK */
+    uint8_t device_id;
+    uint8_t lock_state; /* atapi_pt_lock_state_t */
+} __attribute__((packed)) pt_v4vcmd_acquire_lock_response_t;
+
+typedef struct {
+    uint8_t cmd; /* ATAPI_PTV4V_RELEASE_LOCK */
+    uint8_t device_id;
+} __attribute__((packed)) pt_v4vcmd_release_lock_request_t;
+
+typedef struct {
+    uint8_t cmd; /* ATAPI_PTV4V_SG_GET_RESERVED_SIZE */
+    uint8_t device_id;
+} __attribute__((packed)) pt_v4vcmd_sg_get_reserved_size_request_t;
+
+typedef struct {
+    uint8_t cmd; /* ATAPI_PTV4V_SG_GET_RESERVED_SIZE */
+    uint8_t device_id;
+    uint32_t size;
+} __attribute__((packed)) pt_v4vcmd_sg_get_reserved_size_response_t;
+
+typedef struct {
+    uint8_t cmd; /* ATAPI_PTV4V_SG_IO */
+    uint8_t device_id;
+    struct sg_io_v4 sgio;
+    uint8_t request_data[12]; /* ATAPI_PACKET_SIZE */
+    uint32_t dout_data_len;
+    uint8_t dout_data[];
+} __attribute__((packed)) pt_v4vcmd_sg_io_request_t;
+
+typedef struct {
+    uint8_t cmd; /* ATAPI_PTV4V_SG_IO */
+    uint8_t device_id;
+    struct sg_io_v4 sgio;
+    uint8_t sense_data[64]; /* struct request_sense */
+    uint32_t din_data_len;
+    uint8_t din_data[];
+} __attribute__((packed)) pt_v4vcmd_sg_io_response_t;
+
+#endif /* !_ATAPI_PT_V4V_H_ */

--- a/atapi_pt_helper/src/version.c
+++ b/atapi_pt_helper/src/version.c
@@ -22,21 +22,4 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-
-static char rcsid[] = "$Id: version.c,v 1.1 2009/07/31 11:58:28 jamesmck Exp $";
-
-/*
- * $Log: version.c,v $
- * Revision 1.1  2009/07/31 11:58:28  jamesmck
- * *** empty log message ***
- *
- */
-
-
 #include "version.h"
-
-static char *
-get_version(void)
-{
-  return VERSION;
-}


### PR DESCRIPTION
- Enabled -Wall -Werror CFLAGS.
- Removed unused version bits that caused (error) warnnings.
- Dropped shared memory usage, all that logic is in the
  qemu & xenstore / toolstack side.
- Fixed buggy fnctl() usage.
- Rewrote atapi-pt-v4v protocol using definitions
  in atapi_pt_v4v.h.
- Enforce stricter usage of SG_IO.
- Added lots of error checking, eliminating some potential
  vulnerabilities in the APIs.
- Made logging more consistent with atapi-pt on qemu side.
- Use syslog for logging instead of stderr.

OXT-215

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
