### PR TITLE
[xcpmd] Govern screen brightness by policy and add default policy

### DIFF
--- a/xcpmd/src/Makefile.am
+++ b/xcpmd/src/Makefile.am
@@ -75,6 +75,10 @@ AM_CFLAGS=-g -W -Wall -Werror -Wno-unused -std=gnu99
 bindir="/usr/share/xcpmd"
 dist_config_SCRIPTS = screen_on.sh screen_off.sh
 
+# Package up default rules.
+configdir="/usr/share/xcpmd"
+dist_config_DATA = default.rules
+
 # Discard the .la files libtool produces.
 install-exec-hook:
 	rm $(DESTDIR)$(libdir)/$(PACKAGE)/*.la

--- a/xcpmd/src/Makefile.am
+++ b/xcpmd/src/Makefile.am
@@ -41,7 +41,7 @@ BUILT_SOURCES = ${DBUS_CLIENT_IDLS:%=rpcgen/%_client.h} \
 
 
 # Use libtool to build our .so files.
-pkglib_LTLIBRARIES = default-actions-module.la acpi-module.la vm-actions-module.la default-inputs-module.la vm-events-module.la
+pkglib_LTLIBRARIES = default-actions-module.la acpi-module.la vm-actions-module.la default-inputs-module.la vm-events-module.la screen-module.la
 
 default_inputs_module_la_SOURCES = default-inputs-module.c default-inputs-module.h rules.h
 default_inputs_module_la_LDFLAGS = -avoid-version -module -shared
@@ -58,6 +58,9 @@ vm_actions_module_la_LDFLAGS = -avoid-version -module -shared
 vm_events_module_la_SOURCES = vm-events-module.c project.h xcpmd.h modules.h rules.h vm-events-module.h vm-utils.h
 vm_events_module_la_LDFLAGS = -avoid-version -module -shared
 
+screen_module_la_SOURCES = screen-module.c project.h xcpmd.h rules.h
+screen_module_la_LIBADD = -lm
+screen_module_la_LDFLAGS = -avoid-version -module -shared
 
 
 SRCS=xcpmd.c acpi-events.c platform.c version.c rpcgen/xcpmd_server_obj.c xcpmd-dbus-server.c utils.c rules.c modules.c battery.c parser.c db-helper.c vm-utils.c
@@ -67,6 +70,10 @@ xcpmd_LDFLAGS = -rdynamic
 
 
 AM_CFLAGS=-g -W -Wall -Werror -Wno-unused -std=gnu99
+
+# Package up screen on/off scripts.
+bindir="/usr/share/xcpmd"
+dist_config_SCRIPTS = screen_on.sh screen_off.sh
 
 # Discard the .la files libtool produces.
 install-exec-hook:

--- a/xcpmd/src/acpi-events.c
+++ b/xcpmd/src/acpi-events.c
@@ -40,17 +40,6 @@ static struct event acpi_event;
 
 static struct ev_wrapper ** acpi_event_table;
 
-void adjust_brightness(int increase, int force) {
-
-    if ( force || (pm_quirks & PM_QUIRK_SW_ASSIST_BCL) || (pm_quirks & PM_QUIRK_HP_HOTKEY_INPUT)) {
-        if (increase)
-            com_citrix_xenclient_surfman_increase_brightness_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
-        else
-            com_citrix_xenclient_surfman_decrease_brightness_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
-    }
-}
-
-
 int get_ac_adapter_status(void) {
 
     char data[128];
@@ -244,13 +233,11 @@ static void handle_bcl_event(enum BCL_CMD cmd) {
         xcpmd_log(LOG_INFO, "Brightness up button pressed event\n");
         xenstore_write("1", XS_BCL_CMD);
         xenstore_write("1", XS_BCL_EVENT_PATH);
-        adjust_brightness(1, 0);
     }
     else if (cmd == BCL_DOWN) {
         xcpmd_log(LOG_INFO, "Brightness down button pressed event\n");
         xenstore_write("2", XS_BCL_CMD);
         xenstore_write("1", XS_BCL_EVENT_PATH);
-        adjust_brightness(0, 0);
     }
     else if (cmd == BCL_CYCLE) {
         //Qemu doesn't currently support this key, but these can be uncommented

--- a/xcpmd/src/acpi-events.c
+++ b/xcpmd/src/acpi-events.c
@@ -542,11 +542,14 @@ int xcpmd_process_input(int input_value) {
         case XCPMD_INPUT_SLEEP:
             handle_sleep_button_event();
             break;
+        /* HP laptops and a few Dells use input events for brightness */
         case XCPMD_INPUT_BRIGHTNESSUP:
+            if (pm_quirks & PM_QUIRK_HOTKEY_INPUT)
+                handle_bcl_event(BCL_UP);
+            break;
         case XCPMD_INPUT_BRIGHTNESSDOWN:
-            /* Only HP laptops use input events for brightness */
-            if (pm_quirks & PM_QUIRK_HP_HOTKEY_INPUT)
-                handle_bcl_event(input_value == XCPMD_INPUT_BRIGHTNESSUP ? BCL_UP : BCL_DOWN);
+            if (pm_quirks & PM_QUIRK_HOTKEY_INPUT)
+                handle_bcl_event(BCL_DOWN);
             break;
         default:
             xcpmd_log(LOG_WARNING, "Input invalid value %d\n", input_value);

--- a/xcpmd/src/acpi-module.c
+++ b/xcpmd/src/acpi-module.c
@@ -89,8 +89,8 @@ static struct event_data_row event_data[] = {
 
 
 static struct cond_table_row condition_data[] = {
-    {"onBacklightDownBtn"          , bcl_up_pressed               , "n"    , "void"                        , EVENT_BCL         } ,
-    {"onBacklightUpBtn"            , bcl_down_pressed             , "n"    , "void"                        , EVENT_BCL         } ,
+    {"onBacklightUpBtn"            , bcl_up_pressed               , "n"    , "void"                        , EVENT_BCL         } ,
+    {"onBacklightDownBtn"          , bcl_down_pressed             , "n"    , "void"                        , EVENT_BCL         } ,
     {"onPowerBtn"                  , pbtn_pressed                 , "n"    , "void"                        , EVENT_PWR_BTN     } ,
     {"onSleepBtn"                  , sbtn_pressed                 , "n"    , "void"                        , EVENT_SLP_BTN     } ,
     {"onSuspendBtn"                , susp_pressed                 , "n"    , "void"                        , EVENT_SUSP_BTN    } ,

--- a/xcpmd/src/db-helper.c
+++ b/xcpmd/src/db-helper.c
@@ -330,7 +330,7 @@ bool parse_db_rules(struct parse_data * data) {
         conditions = rule_arr[1];
         actions = rule_arr[2];
         undos = rule_arr[3];
-
+    
         if (!parse_rule_persistent(data, name, conditions, actions, undos)) {
             xcpmd_log(LOG_WARNING, "Error reading DB rule %s - %s", rule_name, extract_parse_error(data));
         }
@@ -458,7 +458,7 @@ static char ** json_rule_to_parseable(char * name, char * json) {
         //Get its arguments, if it has any.
         yajl_path[0] = "args";
         yargs = yajl_tree_get(ycond, yajl_path, yajl_t_any);
-        if ((YAJL_IS_STRING(yargs) && *(YAJL_GET_STRING(yargs))) == '\0') {
+        if ((YAJL_IS_STRING(yargs) && (*(YAJL_GET_STRING(yargs))) == '\0')) {
             //Having no arguments is fine
         }
         else if (!YAJL_IS_OBJECT(yargs)) {
@@ -522,7 +522,7 @@ static char ** json_rule_to_parseable(char * name, char * json) {
         //Get its args, if it has any.
         yajl_path[0] = "args";
         yargs = yajl_tree_get(yact, yajl_path, yajl_t_any);
-        if (YAJL_IS_STRING(yargs) && *(YAJL_GET_STRING(yargs)) == '\0') {
+        if ((YAJL_IS_STRING(yargs) && (*(YAJL_GET_STRING(yargs))) == '\0')) {
             //Having no args is fine.
         }
         else if (!YAJL_IS_OBJECT(yargs)) {
@@ -587,7 +587,7 @@ static char ** json_rule_to_parseable(char * name, char * json) {
 
             yajl_path[0] = "args";
             yargs = yajl_tree_get(yundo, yajl_path, yajl_t_any);
-            if (YAJL_IS_STRING(yargs) && *(YAJL_GET_STRING(yargs)) == '\0') {
+            if ((YAJL_IS_STRING(yargs) && (*(YAJL_GET_STRING(yargs))) == '\0')) {
                 //Having no args is fine.
             }
             else if (!YAJL_IS_OBJECT(yargs)) {

--- a/xcpmd/src/default.rules
+++ b/xcpmd/src/default.rules
@@ -1,0 +1,15 @@
+# Default set of rules for XCPMD. These are only loaded when no rules or vars
+# exist in the DB.
+
+# Variable section
+battCritical(10)
+criticalBrightness(60)
+brightnessOnBatt(75)
+=
+
+# Rules section
+lidScreenPower | whileLidClosed() | screenOff() | screenOn()
+dimScreenCritical | whileUsingBatt() whileOverallBattLessThan($battCritical) | setBacklight($criticalBrightness) | setBacklight($brightnessOnBatt)
+dimScreenOnBatt | whileUsingBatt() | setBacklight($brightnessOnBatt) | setBacklight(100)
+brightnessUpKey | onBacklightUpBtn() | increaseBacklight(7)
+brightnessDownKey | onBacklightDownBtn() | decreaseBacklight(7)

--- a/xcpmd/src/modules.c
+++ b/xcpmd/src/modules.c
@@ -315,3 +315,14 @@ int load_policy_from_file(char * filename) {
     return 0;
 }
 
+
+//Checks if any rules or variables have yet been added.
+bool policy_exists(void) {
+
+    if (list_empty(&rules.list) && list_empty(&db_vars.list)) {
+        return false;
+    }
+    else {
+        return true;
+    }
+}

--- a/xcpmd/src/modules.c
+++ b/xcpmd/src/modules.c
@@ -306,7 +306,7 @@ int load_policy_from_db() {
 //See parser.c for information on policy file format.
 int load_policy_from_file(char * filename) {
 
-    if (!parse_config_from_file(filename))
+    if (parse_config_from_file(filename) == -1)
         return -1;
 
     write_db_rules();

--- a/xcpmd/src/modules.c
+++ b/xcpmd/src/modules.c
@@ -47,7 +47,8 @@ static char * _module_list[] = {
     MODULE_PATH "acpi-module.so",
     MODULE_PATH "vm-actions-module.so",
     MODULE_PATH "default-actions-module.so",
-    MODULE_PATH "vm-events-module.so"
+    MODULE_PATH "vm-events-module.so",
+    MODULE_PATH "screen-module.so"
 };
 
 

--- a/xcpmd/src/modules.h
+++ b/xcpmd/src/modules.h
@@ -40,4 +40,6 @@ int load_policy_from_db();
 int load_policy_from_file(char * filename);
 void evaluate_policy();
 
+bool policy_exists();
+
 #endif

--- a/xcpmd/src/parser.c
+++ b/xcpmd/src/parser.c
@@ -1881,6 +1881,7 @@ int parse_config_from_file(char * filename) {
     char * string, *ptr, *token_start, *token_end, *string_end;
     bool in_var_section = true;
     bool in_quotes;
+    bool whitespace_line;
 
     memset(&data, 0, sizeof(struct parse_data));
     memset(&var_map, 0, sizeof(struct var_map));
@@ -1900,10 +1901,26 @@ int parse_config_from_file(char * filename) {
     while (fgets(line, 1024, file)) {
 
         line_no++;
+        xcpmd_log(LOG_DEBUG, "Parsing line %d: %s", line_no, line);
 
         //Discard any line beginning with a comment character (#).
         if (line[0] == '#')
             continue;
+
+        //Discard any lines containing only whitespace.
+        whitespace_line = false;
+        ptr = line;
+        while (*ptr <= ' ') {
+            if (*ptr == '\0') {
+                whitespace_line = true;
+                break;
+            }
+            ++ptr;
+        }
+        if (whitespace_line) {
+            xcpmd_log(LOG_DEBUG, "Line %d was whitespace.", line_no);
+            continue;
+        }
 
         //Discard any lines longer than 1024 characters.
         if (strchr(line, '\n') == NULL) {
@@ -1964,7 +1981,6 @@ int parse_config_from_file(char * filename) {
                 }
                 ptr += sizeof(char);
             }
-
 
             init_parse_data(&data, &var_map, data.start_state, name, NULL, conditions, actions, undos, TYPE_RULE);
             if (!parse(&data, data.conditions_str)) {

--- a/xcpmd/src/platform.c
+++ b/xcpmd/src/platform.c
@@ -44,6 +44,8 @@
 #define DELL_E5220               "E5220"
 #define DELL_E5420               "E5420"
 #define DELL_E5520               "E5520"
+#define DELL_E6330               "E6330"
+#define DELL_E6430               "E6430"
 #define TOSHIBA_TECRA            "TECRA"
 
 /* PCI Values */
@@ -56,6 +58,7 @@
 #define MONTEVINA_GMCH_ID        0x2a40
 #define CALPELLA_GMCH_ID         0x0044
 #define SANDYBRIDGE_GMCH_ID      0x0104
+#define IVYBRIDGE_GMCH_ID        0x0154
 
 #define PCI_VENDOR_ID_WORD(v) ((uint16_t)(0xffff & (v)))
 #define PCI_DEVICE_ID_WORD(v) ((uint16_t)(0xffff & (v >> 16)))
@@ -371,7 +374,7 @@ static void setup_software_bcl_and_input_quirks(void)
          * functionality for those keys via WMI. The flag allows the backend to field a few
          * of the hotkey presses when no guests are using them by processing the keyboard (via QLB).
          */
-        pm_quirks |= PM_QUIRK_HP_HOTKEY_INPUT;
+        pm_quirks |= PM_QUIRK_HOTKEY_INPUT;
 
         /* Almost all the HPs used KB input for adjusting the brightness until an HDX VM is run with
          * the QLB/HotKey software. Once this VM is running, the guest software takes over and the BIOS
@@ -391,6 +394,10 @@ static void setup_software_bcl_and_input_quirks(void)
         /* MV and CP systems seem to use firmware BCL control but SB and IB do not */
         if ( (pci_gmch_id == MONTEVINA_GMCH_ID) || (pci_gmch_id == CALPELLA_GMCH_ID) )
             pm_quirks &= ~(PM_QUIRK_SW_ASSIST_BCL|PM_QUIRK_SW_ASSIST_BCL_IGFX_PT);
+
+        /* The E6330 and E6430 send BCL buttons as input events. */
+        if ( strstr(product, DELL_E6330) || strstr(product, DELL_E6430) )
+            pm_quirks |= PM_QUIRK_HOTKEY_INPUT;
     }
     else if ( strnicmp(manufacturer, MANUFACTURER_LENOVO, strlen(MANUFACTURER_LENOVO)) == 0 )
     {

--- a/xcpmd/src/prototypes.h
+++ b/xcpmd/src/prototypes.h
@@ -20,7 +20,6 @@
 
 /* acpi-events.c */
 int xcpmd_process_input(int input_value);
-void adjust_brightness(int increase, int force);
 int get_ac_adapter_status(void);
 int get_lid_status(void);
 int acpi_events_initialize(void);

--- a/xcpmd/src/screen-module.c
+++ b/xcpmd/src/screen-module.c
@@ -1,0 +1,317 @@
+/*
+ * screen-module.c
+ *
+ * XCPMD module that provides display power management actions.
+ *
+ * Copyright (c) 2015 Assured Information Security, Inc.
+ *
+ * Author:
+ * Jennifer Temkin <temkinj@ainfosec.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "project.h"
+#include "xcpmd.h"
+#include "rpcgen/surfman_client.h"
+#include "rules.h"
+#include <math.h>
+
+//Function prototypes
+void screen_on(struct arg_node * args);
+void screen_off(struct arg_node * args);
+void set_backlight(struct arg_node * args);
+void increase_backlight(struct arg_node * args);
+void decrease_backlight(struct arg_node * args);
+static int get_brightness(void);
+static void set_brightness(int percentage);
+
+
+//Private data structures
+struct action_table_row {
+    char * name;
+    void (* func)(struct arg_node *);
+    char * prototype;
+    char * pretty_prototype;
+};
+
+
+//Private data
+static struct action_table_row action_table[] = {
+    {"screenOn"          , screen_on          , "n" , "void"                    } ,
+    {"screenOff"         , screen_off         , "n" , "void"                    } ,
+    {"setBacklight"      , set_backlight      , "i" , "int backlight_percent"   } ,
+    {"increaseBacklight" , increase_backlight , "i" , "int percent_to_increase" } ,
+    {"decreaseBacklight" , decrease_backlight , "i" , "int percent_to_decrease" }
+};
+
+static unsigned int num_action_types = sizeof(action_table) / sizeof(action_table[0]);
+static int times_loaded = 0;
+
+
+//Registers this module's action types.
+//The constructor attribute causes this function to run at load (dlopen()) time.
+__attribute__ ((constructor)) static void init_module() {
+
+    unsigned int i;
+
+    if (times_loaded > 0)
+        return;
+
+    for (i=0; i < num_action_types; ++i) {
+        add_action_type(action_table[i].name, action_table[i].func, action_table[i].prototype, action_table[i].pretty_prototype);
+    }
+}
+
+
+//Cleans up after this module.
+//The destructor attribute causes this to run at unload (dlclose()) time.
+__attribute__ ((destructor)) static void uninit_module() {
+
+    --times_loaded;
+
+    //if (times_loaded > 0)
+    //    return;
+
+    return;
+}
+
+
+//Actions
+//Calls a script that asks vbetool to set DPMS=on, then asks surfman to remodeset.
+void screen_on(struct arg_node * args) {
+    //Automatically background the new process so we don't block on it.
+    char * command = safe_sprintf("%s &", SCREEN_ON_SCRIPT);
+    system(command);
+    free(command);
+}
+
+
+//Calls a script that asks vbetool to set DPMS=off.
+void screen_off(struct arg_node * args) {
+    //Automatically background the new process so we don't block on it.
+    char * command = safe_sprintf("%s &", SCREEN_OFF_SCRIPT);
+    system(command);
+    free(command);
+}
+
+
+//Sets the backlight to as close to the desired percentage as surfman allows.
+void set_backlight(struct arg_node * args) {
+
+    struct arg_node * node = get_arg(args, 0);
+    set_brightness(node->arg.i);
+}
+
+
+//Increases the backlight by as close to the current percentage as surfman allows.
+void increase_backlight(struct arg_node * args) {
+
+    struct arg_node * node = get_arg(args, 0);
+    unsigned int old_backlight, new_backlight;
+
+    old_backlight = get_brightness();
+    new_backlight = old_backlight + node->arg.i;
+
+    if (new_backlight > 100) {
+        new_backlight = 100;
+    }
+    else if (new_backlight < old_backlight) {
+        new_backlight = old_backlight;
+    }
+
+    set_brightness(new_backlight);
+}
+
+
+//Increases the backlight by as close to the current percentage as surfman allows.
+void decrease_backlight(struct arg_node * args) {
+
+    struct arg_node * node = get_arg(args, 0);
+    unsigned int old_backlight;
+    int new_backlight;
+
+    old_backlight = get_brightness();
+    new_backlight = old_backlight - node->arg.i;
+
+    if (new_backlight < 0) {
+        new_backlight = 0;
+    }
+    else if ((unsigned)new_backlight > old_backlight) {
+        new_backlight = old_backlight;
+    }
+
+    set_brightness((unsigned int)new_backlight);
+}
+
+
+//Get the current backlight in percent.
+static int get_brightness(void) {
+
+    DIR *sys_dir, *backlight_dir;
+    struct dirent * dp;
+    FILE * file;
+    char data[128];
+    char *device_name = NULL, *path = NULL;
+    int brightness, max_brightness, percent;
+
+    //Get the backlight directory.
+    sys_dir = opendir(BACKLIGHT_PATH);
+    if (!sys_dir) {
+        xcpmd_log(LOG_WARNING, "Couldn't open backlight dir %s - error %d\n", BACKLIGHT_PATH, errno);
+        return 0;
+    }
+
+    //There can be more than one backlight device, and the names of these
+    //devices may vary from platform to platform. They should all report
+    //correct values, so just choose the first one.
+    while ((dp = readdir(sys_dir)) != NULL) {
+        if (dp->d_type == DT_LNK) {
+            device_name = clone_string(dp->d_name);
+            break;
+        }
+    }
+    if (device_name == NULL) {
+        xcpmd_log(LOG_WARNING, "No backlight devices found in %s\n", BACKLIGHT_PATH);
+        closedir(sys_dir);
+        return 0;
+    }
+    closedir(sys_dir);
+
+    //Get the current brightness and max brightness.
+    path = safe_sprintf("%s/%s/%s", BACKLIGHT_PATH, device_name, "actual_brightness");
+    file = fopen(path, "r");
+    if (file == NULL) {
+        xcpmd_log(LOG_WARNING, "Couldn't open file %s - error %d\n", path, errno);
+        free(path);
+        return 0;
+    }
+
+    fgets(data, sizeof(data), file);
+    brightness = atoi(data);
+    fclose(file);
+    free(path);
+
+    path = safe_sprintf("%s/%s/%s", BACKLIGHT_PATH, device_name, "max_brightness");
+    file = fopen(path, "r");
+    if (file == NULL) {
+        xcpmd_log(LOG_WARNING, "Couldn't open file %s - error %d\n", path, errno);
+        free(path);
+        return 0;
+    }
+
+    fgets(data, sizeof(data), file);
+    max_brightness = atoi(data);
+    fclose(file);
+    free(path);
+
+    //Convert backlight to percent.
+    if (max_brightness == 0) {
+        percent = 0;
+    }
+    else {
+        percent = (brightness * 100) / max_brightness;
+    }
+
+    return percent;
+}
+
+
+//Surfman doesn't have a method to set this directly, so we have to do it the
+//roundabout way.
+static void set_brightness(int percent) {
+
+    DIR *sys_dir, *backlight_dir;
+    struct dirent * dp;
+    FILE * file;
+    char data[128];
+    char *device_name = NULL, *path = NULL;
+    int brightness, max_brightness, desired_brightness;
+    int surfman_step_size, desired_steps, current_steps, steps_to_take;
+    int i;
+
+    //Get the backlight directory.
+    sys_dir = opendir(BACKLIGHT_PATH);
+    if (!sys_dir) {
+        xcpmd_log(LOG_WARNING, "Couldn't open backlight dir %s - error %d\n", BACKLIGHT_PATH, errno);
+        return;
+    }
+
+    //There can be more than one backlight device, and the names of these
+    //devices may vary from platform to platform. They should all report
+    //correct values, so just choose the first one.
+    while ((dp = readdir(sys_dir)) != NULL) {
+        if (dp->d_type == DT_LNK) {
+            device_name = clone_string(dp->d_name);
+            break;
+        }
+    }
+    if (device_name == NULL) {
+        xcpmd_log(LOG_WARNING, "No backlight devices found in %s\n", BACKLIGHT_PATH);
+        closedir(sys_dir);
+        return;
+    }
+    closedir(sys_dir);
+
+    //Get the current brightness and max brightness.
+    path = safe_sprintf("%s/%s/%s", BACKLIGHT_PATH, device_name, "actual_brightness");
+    file = fopen(path, "r");
+    if (file == NULL) {
+        xcpmd_log(LOG_WARNING, "Couldn't open file %s - error %d\n", path, errno);
+        free(path);
+        return;
+    }
+
+    fgets(data, sizeof(data), file);
+    brightness = atoi(data);
+    fclose(file);
+    free(path);
+
+    path = safe_sprintf("%s/%s/%s", BACKLIGHT_PATH, device_name, "max_brightness");
+    file = fopen(path, "r");
+    if (file == NULL) {
+        xcpmd_log(LOG_WARNING, "Couldn't open file %s - error %d\n", path, errno);
+        free(path);
+        return;
+    }
+
+    fgets(data, sizeof(data), file);
+    max_brightness = atoi(data);
+    fclose(file);
+    free(path);
+    free(device_name);
+
+    //Surfman currently supports 15 levels of brightness. Get the step size.
+    surfman_step_size = max_brightness / 15;
+
+    //Determine the desired brightness.
+    desired_brightness = (percent * max_brightness) / 100;
+
+    //Determine how many times we'll need to ask surfman to change the brightness.
+    current_steps = brightness / surfman_step_size;
+    desired_steps = round((float)desired_brightness / (float)surfman_step_size);
+    steps_to_take = desired_steps - current_steps;
+
+    //Adjust brightness.
+    if (steps_to_take > 0) {
+        for (i = 0; i < steps_to_take; ++i) {
+            com_citrix_xenclient_surfman_increase_brightness_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
+        }
+    }
+    else if (steps_to_take < 0) {
+        for (i = 0; i > steps_to_take; --i) {
+            com_citrix_xenclient_surfman_decrease_brightness_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
+        }
+    }
+}

--- a/xcpmd/src/screen_off.sh
+++ b/xcpmd/src/screen_off.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# screen_off.sh
+#
+# Script that powers off a display.
+#
+# Copyright (c) 2015 Assured Information Security, Inc.
+#
+# Author:
+# Jennifer Temkin <temkinj@ainfosec.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 2
+# as published by the Free Software Foundation
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+timeout 10 vbetool dpms off
+exit 0

--- a/xcpmd/src/screen_on.sh
+++ b/xcpmd/src/screen_on.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# screen_on.sh
+#
+# Script that powers on and remodesets a powered-off display.
+#
+# Copyright (c) 2015 Assured Information Security, Inc.
+#
+# Author:
+# Jennifer Temkin <temkinj@ainfosec.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 2
+# as published by the Free Software Foundation
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+timeout 10 vbetool dpms on
+VM=$(dbus-send --system --print-reply --dest=com.citrix.xenclient.surfman / org.citrix.xenclient.surfman.get_visible | awk '/int32/ {print $2}')
+dbus-send --system --dest=com.citrix.xenclient.surfman --type=method_call / org.citrix.xenclient.surfman.set_visible array:int32:0 int32:0 boolean:false
+dbus-send --system --dest=com.citrix.xenclient.surfman --type=method_call / org.citrix.xenclient.surfman.set_visible array:int32:$VM int32:0 boolean:false
+
+exit 0

--- a/xcpmd/src/vm-events-module.c
+++ b/xcpmd/src/vm-events-module.c
@@ -367,7 +367,11 @@ void vm_state_changed(DBusMessage * dbus_message) {
 	struct vm_identifier_table_row * vmid;
 
 
-    dbus_message_get_args(dbus_message, &error, DBUS_TYPE_STRING, &vm_uuid, DBUS_TYPE_OBJECT_PATH, &obj_path, DBUS_TYPE_STRING, &vm_state, DBUS_TYPE_INT32, &acpi_state);
+    if (!dbus_message_get_args(dbus_message, &error, DBUS_TYPE_STRING, &vm_uuid, DBUS_TYPE_OBJECT_PATH, &obj_path, DBUS_TYPE_STRING, &vm_state, DBUS_TYPE_INT32, &acpi_state)) {
+        xcpmd_log(LOG_WARNING, "DBus error in com.citrix.xenclient.xenmgr.vm_state_changed: %s\n", error.message); 
+        dbus_error_free(&error);
+        return;
+    }
 
     //For whatever reason the "creating" signal is fired multiple times, but
     //only once does it have the acpi_state of 5. At present, the acpi_state is

--- a/xcpmd/src/xcpmd.c
+++ b/xcpmd/src/xcpmd.c
@@ -121,8 +121,11 @@ int main(int argc, char *argv[]) {
     }
 
 #ifdef POLICY_FILE_PATH
-    if (load_policy_from_file(POLICY_FILE_PATH) == -1) {
-        xcpmd_log(LOG_WARNING, "Error loading policy from file %s; continuing...\n", POLICY_FILE_PATH);
+    if (!policy_exists()) {
+        xcpmd_log(LOG_INFO, "No DB policy found; loading default policy from %s.\n", POLICY_FILE_PATH);
+        if (load_policy_from_file(POLICY_FILE_PATH) == -1) {
+            xcpmd_log(LOG_WARNING, "Error loading policy from file %s; continuing...\n", POLICY_FILE_PATH);
+        }
     }
 #endif
 

--- a/xcpmd/src/xcpmd.h
+++ b/xcpmd/src/xcpmd.h
@@ -272,8 +272,9 @@ extern uint32_t pm_specs;
 #define DB_VAR_MAP_PATH                     "/power-management/vars"
 #define DB_RULE_PATH                        "/power-management/rules"
 
+#define POLICY_FILE_PATH                    "/usr/share/xcpmd/default.rules"
 #define SCREEN_ON_SCRIPT                    "/usr/share/xcpmd/screen_on.sh"
-#define SCREEN_OFF_SCRIPT                    "/usr/share/xcpmd/screen_off.sh"
+#define SCREEN_OFF_SCRIPT                   "/usr/share/xcpmd/screen_off.sh"
 
 #endif /* __XCPMD_H__ */
 

--- a/xcpmd/src/xcpmd.h
+++ b/xcpmd/src/xcpmd.h
@@ -189,6 +189,7 @@ struct battery_status {
 #define LID_DIR_PATH2                       "/proc/acpi/button/lid/LID0"
 #define LID_STATE_FILE_PATH                 LID_DIR_PATH"/state"
 #define LID_STATE_FILE_PATH2                LID_DIR_PATH2"/state"
+#define BACKLIGHT_PATH                      "/sys/class/backlight"
 #define ACPID_SOCKET_PATH                   "/var/run/acpid.socket"
 
 #define XS_FORMAT_PATH_LEN                  128
@@ -270,6 +271,9 @@ extern uint32_t pm_specs;
 #define DB_PM_PATH                          "/power-management"
 #define DB_VAR_MAP_PATH                     "/power-management/vars"
 #define DB_RULE_PATH                        "/power-management/rules"
+
+#define SCREEN_ON_SCRIPT                    "/usr/share/xcpmd/screen_on.sh"
+#define SCREEN_OFF_SCRIPT                    "/usr/share/xcpmd/screen_off.sh"
 
 #endif /* __XCPMD_H__ */
 

--- a/xcpmd/src/xcpmd.h
+++ b/xcpmd/src/xcpmd.h
@@ -253,7 +253,7 @@ struct battery_status {
 #define PM_QUIRK_SW_ASSIST_BCL              0x0000001 /* platform needs SW assistance with brightness adjustments */
 #define PM_QUIRK_SW_ASSIST_BCL_IGFX_PT      0x0000002 /* platform needs SW assistance with brightness adjustments with Intel GPU pass-through */
 #define PM_QUIRK_SW_ASSIST_BCL_HP_SB        0x0000004 /* set of HP SB platforms need SW assistance due to BIOS not switching to OpRegion use */
-#define PM_QUIRK_HP_HOTKEY_INPUT            0x0010000 /* HP platforms generate keyboard input for hotkeys */
+#define PM_QUIRK_HOTKEY_INPUT               0x0010000 /* Some platforms generate keyboard input for hotkeys */
 
 extern uint32_t pm_quirks;
 


### PR DESCRIPTION
All actions concerning screen brightness have been pulled into a module, screen-module.so, which makes brightness-related actions available for use in rules.

A default policy has also been added that should be general and flexible enough for all platforms. On a laptop:
- it turns off the display when the lid is closed and turns it back on when the lid is opened;
- it dims the display to 75% when the laptop is unplugged, and restores it to 100% when plugged in;
- it dims the display to 60% when the laptop is unplugged and battery percentage reaches the critical level of 10%; and
- it increases or decreases the backlight when backlight keys are pressed.

This PR also includes a handful of fixes for other bugs I encountered while testing the two features above.

The SELinux policy required for these features is in [xenclient-oe PR193](https://github.com/OpenXT/xenclient-oe/pull/193).
