### PR TITLE
[xcpmd] Bring back missing quirk check for Dell brightness keys

### DIFF
--- a/xcpmd/src/acpi-events.c
+++ b/xcpmd/src/acpi-events.c
@@ -557,8 +557,8 @@ int xcpmd_process_input(int input_value) {
             break;
         case XCPMD_INPUT_BRIGHTNESSUP:
         case XCPMD_INPUT_BRIGHTNESSDOWN:
-            /* Only HP laptops use input events for brightness */
-            if (pm_quirks & PM_QUIRK_HP_HOTKEY_INPUT)
+            /* Some laptops use input events for brightness */
+            if (pm_quirks & (PM_QUIRK_HP_HOTKEY_INPUT | PM_QUIRK_SW_ASSIST_BCL))
                 handle_bcl_event(input_value == XCPMD_INPUT_BRIGHTNESSUP ? BCL_UP : BCL_DOWN);
             break;
         default:


### PR DESCRIPTION
The check for this quirk got lost when I was refactoring. This should fix [OXT-405](https://openxt.atlassian.net/browse/OXT-405) for the Dell platforms in question--I don't have a 7440/7450, but it works on the 6330 I have here. 
