### PR TITLE
[xcpmd] dbus_message_get_args usage

### DIFF
--- a/xcpmd/src/vm-events-module.c
+++ b/xcpmd/src/vm-events-module.c
@@ -364,10 +364,20 @@ void vm_state_changed(DBusMessage * dbus_message) {
     char * vm_state;
     int acpi_state;
     struct ev_wrapper * e;
-	struct vm_identifier_table_row * vmid;
+    struct vm_identifier_table_row * vmid;
 
-
-    dbus_message_get_args(dbus_message, &error, DBUS_TYPE_STRING, &vm_uuid, DBUS_TYPE_OBJECT_PATH, &obj_path, DBUS_TYPE_STRING, &vm_state, DBUS_TYPE_INT32, &acpi_state);
+    dbus_error_init(&error);
+    if (!dbus_message_get_args(dbus_message, &error,
+                               DBUS_TYPE_STRING, &vm_uuid,
+                               DBUS_TYPE_OBJECT_PATH, &obj_path,
+                               DBUS_TYPE_STRING, &vm_state,
+                               DBUS_TYPE_INT32, &acpi_state,
+                               DBUS_TYPE_INVALID)) {
+        xcpmd_log(LOG_ERR, "dbus_message_get_args() failed: %s (%s).\n",
+                  error.name, error.message);
+        dbus_error_free(&error);
+        return;
+    }
 
     //For whatever reason the "creating" signal is fired multiple times, but
     //only once does it have the acpi_state of 5. At present, the acpi_state is


### PR DESCRIPTION
https://dbus.freedesktop.org/doc/api/html/group__DBusMessage.html#gad8953f53ceea7de81cde792e3edd0230
"The list is terminated with DBUS_TYPE_INVALID."

Using the error: "org.freedesktop.DBus.Error.InvalidArgs (Message has only 4 arguments, but more were expected)"

That can SIGABRT xcpmd when daemonized, it was restarted by monit, hiding the issue.
