### PR TITLE
Default policy [OXT-449] and screen brightness module [OXT-450]

### DIFF
--- a/xcpmd/src/Makefile.am
+++ b/xcpmd/src/Makefile.am
@@ -41,7 +41,7 @@ BUILT_SOURCES = ${DBUS_CLIENT_IDLS:%=rpcgen/%_client.h} \
 
 
 # Use libtool to build our .so files.
-pkglib_LTLIBRARIES = default-actions-module.la acpi-module.la vm-actions-module.la default-inputs-module.la vm-events-module.la
+pkglib_LTLIBRARIES = default-actions-module.la acpi-module.la vm-actions-module.la default-inputs-module.la vm-events-module.la screen-module.la
 
 default_inputs_module_la_SOURCES = default-inputs-module.c default-inputs-module.h rules.h
 default_inputs_module_la_LDFLAGS = -avoid-version -module -shared
@@ -58,6 +58,9 @@ vm_actions_module_la_LDFLAGS = -avoid-version -module -shared
 vm_events_module_la_SOURCES = vm-events-module.c project.h xcpmd.h modules.h rules.h vm-events-module.h vm-utils.h
 vm_events_module_la_LDFLAGS = -avoid-version -module -shared
 
+screen_module_la_SOURCES = screen-module.c project.h xcpmd.h rules.h
+screen_module_la_LIBADD = -lm
+screen_module_la_LDFLAGS = -avoid-version -module -shared
 
 
 SRCS=xcpmd.c acpi-events.c platform.c rpcgen/xcpmd_server_obj.c xcpmd-dbus-server.c utils.c rules.c modules.c battery.c parser.c db-helper.c vm-utils.c
@@ -67,6 +70,7 @@ xcpmd_LDFLAGS = -rdynamic
 
 
 AM_CFLAGS=-g -W -Wall -Werror -std=gnu99
+
 
 # Discard the .la files libtool produces.
 install-exec-hook:

--- a/xcpmd/src/Makefile.am
+++ b/xcpmd/src/Makefile.am
@@ -72,6 +72,10 @@ xcpmd_LDFLAGS = -rdynamic
 AM_CFLAGS=-g -W -Wall -Werror -std=gnu99
 
 
+# Package up default rules.
+configdir="/usr/share/xcpmd"
+dist_config_DATA = default.rules
+
 # Discard the .la files libtool produces.
 install-exec-hook:
 	rm $(DESTDIR)$(libdir)/$(PACKAGE)/*.la

--- a/xcpmd/src/acpi-events.c
+++ b/xcpmd/src/acpi-events.c
@@ -40,17 +40,6 @@ static struct event acpi_event;
 
 static struct ev_wrapper ** acpi_event_table;
 
-void adjust_brightness(int increase, int force) {
-
-    if ( force || (pm_quirks & PM_QUIRK_SW_ASSIST_BCL) || (pm_quirks & PM_QUIRK_HP_HOTKEY_INPUT)) {
-        if (increase)
-            com_citrix_xenclient_surfman_increase_brightness_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
-        else
-            com_citrix_xenclient_surfman_decrease_brightness_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
-    }
-}
-
-
 int get_ac_adapter_status(void) {
 
     char data[128];
@@ -244,13 +233,11 @@ static void handle_bcl_event(enum BCL_CMD cmd) {
         xcpmd_log(LOG_INFO, "Brightness up button pressed event\n");
         xenstore_write("1", XS_BCL_CMD);
         xenstore_write("1", XS_BCL_EVENT_PATH);
-        adjust_brightness(1, 0);
     }
     else if (cmd == BCL_DOWN) {
         xcpmd_log(LOG_INFO, "Brightness down button pressed event\n");
         xenstore_write("2", XS_BCL_CMD);
         xenstore_write("1", XS_BCL_EVENT_PATH);
-        adjust_brightness(0, 0);
     }
     else if (cmd == BCL_CYCLE) {
         //Qemu doesn't currently support this key, but these can be uncommented

--- a/xcpmd/src/acpi-module.c
+++ b/xcpmd/src/acpi-module.c
@@ -89,8 +89,8 @@ static struct event_data_row event_data[] = {
 
 
 static struct cond_table_row condition_data[] = {
-    {"onBacklightDownBtn"          , bcl_up_pressed               , "n"    , "void"                        , EVENT_BCL         } ,
-    {"onBacklightUpBtn"            , bcl_down_pressed             , "n"    , "void"                        , EVENT_BCL         } ,
+    {"onBacklightUpBtn"            , bcl_up_pressed               , "n"    , "void"                        , EVENT_BCL         } ,
+    {"onBacklightDownBtn"          , bcl_down_pressed             , "n"    , "void"                        , EVENT_BCL         } ,
     {"onPowerBtn"                  , pbtn_pressed                 , "n"    , "void"                        , EVENT_PWR_BTN     } ,
     {"onSleepBtn"                  , sbtn_pressed                 , "n"    , "void"                        , EVENT_SLP_BTN     } ,
     {"onSuspendBtn"                , susp_pressed                 , "n"    , "void"                        , EVENT_SUSP_BTN    } ,

--- a/xcpmd/src/acpi-module.c
+++ b/xcpmd/src/acpi-module.c
@@ -112,8 +112,6 @@ static struct cond_table_row condition_data[] = {
 static unsigned int num_conditions = sizeof(condition_data) / sizeof(condition_data[0]);
 static unsigned int num_events = sizeof(event_data) / sizeof(event_data[0]);
 
-static int times_loaded = 0;
-
 
 //Public data
 struct ev_wrapper ** _acpi_event_table;
@@ -122,9 +120,6 @@ struct ev_wrapper ** _acpi_event_table;
 //Initializes the module.
 //The constructor attribute causes this function to run at load (dlopen()) time.
 __attribute__((constructor)) static void init_module() {
-
-    if (times_loaded > 0)
-        return;
 
     unsigned int i;
 
@@ -147,18 +142,12 @@ __attribute__((constructor)) static void init_module() {
         struct cond_table_row entry = condition_data[i];
         add_condition_type(entry.name, entry.func, entry.prototype, entry.pretty_prototype, _acpi_event_table[entry.event_index]);
     }
-
-    ++times_loaded;
 }
 
 
 //Cleans up after this module.
 //The destructor attribute causes this to run at unload (dlclose()) time.
 __attribute__((destructor)) static void uninit_module() {
-
-    --times_loaded;
-    if (times_loaded > 0)
-        return;
 
     //Free event table.
     free(_acpi_event_table);

--- a/xcpmd/src/battery.c
+++ b/xcpmd/src/battery.c
@@ -75,8 +75,15 @@ int get_battery_charge_state(unsigned int battery_index) {
 
     if (last_status[battery_index].state & 0x1)
         return BATT_DISCHARGING;
-    else if (last_status[battery_index].state & 0x2)
-        return BATT_CHARGING;
+    else if (last_status[battery_index].state & 0x2) {
+        // The Dell Venue 11 Pro 7140 reports state = BATT_CHARGING even when it's full.
+        if (last_status[battery_index].charge_now == last_info[battery_index].design_capacity) {
+            return BATT_FULL;
+        }
+        else {
+            return BATT_CHARGING;
+        }
+    }
     else {
         /* We're not charging nor discharging... */
         percent = get_battery_percentage(battery_index);

--- a/xcpmd/src/db-helper.c
+++ b/xcpmd/src/db-helper.c
@@ -468,7 +468,7 @@ static char ** json_rule_to_parseable(char * name, char * json) {
         //Get its arguments, if it has any.
         yajl_path[0] = "args";
         yargs = yajl_tree_get(ycond, yajl_path, yajl_t_any);
-        if ((YAJL_IS_STRING(yargs) && *(YAJL_GET_STRING(yargs))) == '\0') {
+        if ((YAJL_IS_STRING(yargs) && (*(YAJL_GET_STRING(yargs))) == '\0')) {
             //Having no arguments is fine
         }
         else if (!YAJL_IS_OBJECT(yargs)) {
@@ -532,7 +532,7 @@ static char ** json_rule_to_parseable(char * name, char * json) {
         //Get its args, if it has any.
         yajl_path[0] = "args";
         yargs = yajl_tree_get(yact, yajl_path, yajl_t_any);
-        if (YAJL_IS_STRING(yargs) && *(YAJL_GET_STRING(yargs)) == '\0') {
+        if ((YAJL_IS_STRING(yargs) && (*(YAJL_GET_STRING(yargs))) == '\0')) {
             //Having no args is fine.
         }
         else if (!YAJL_IS_OBJECT(yargs)) {
@@ -597,7 +597,7 @@ static char ** json_rule_to_parseable(char * name, char * json) {
 
             yajl_path[0] = "args";
             yargs = yajl_tree_get(yundo, yajl_path, yajl_t_any);
-            if (YAJL_IS_STRING(yargs) && *(YAJL_GET_STRING(yargs)) == '\0') {
+            if ((YAJL_IS_STRING(yargs) && (*(YAJL_GET_STRING(yargs))) == '\0')) {
                 //Having no args is fine.
             }
             else if (!YAJL_IS_OBJECT(yargs)) {

--- a/xcpmd/src/default-actions-module.c
+++ b/xcpmd/src/default-actions-module.c
@@ -55,7 +55,6 @@ static struct action_table_row action_table[] = {
 };
 
 static unsigned int num_action_types = sizeof(action_table) / sizeof(action_table[0]);
-static int times_loaded = 0;
 
 
 //Registers this module's action types.
@@ -63,16 +62,10 @@ static int times_loaded = 0;
 //they may be shadowed by the constructors of previously loaded modules!
 static void __attribute__ ((constructor)) init_module() {
 
-    //Guard clause--this prevents things from being registered multiple times.
-    if (times_loaded > 0)
-        return;
-
     unsigned int i;
 
     for (i=0; i < num_action_types; ++i)
         add_action_type(action_table[i].name, action_table[i].func, action_table[i].prototype, action_table[i].pretty_prototype);
-
-    ++times_loaded;
 }
 
 

--- a/xcpmd/src/default-inputs-module.c
+++ b/xcpmd/src/default-inputs-module.c
@@ -67,7 +67,6 @@ static const struct cond_table_row condition_table[] = {
 
 static const unsigned int num_events = sizeof(event_data) / sizeof(event_data[0]);
 static const unsigned int condition_table_size = sizeof(condition_table) / sizeof(condition_table[0]);
-static int times_loaded = 0;
 
 
 //Public data
@@ -76,9 +75,6 @@ struct ev_wrapper ** default_event_table;
 
 //Registers this module's events and condition types.
 static void __attribute__((constructor)) init_module() {
-
-    if (times_loaded > 0)
-        return;
 
     unsigned int i;
 
@@ -94,17 +90,11 @@ static void __attribute__((constructor)) init_module() {
         add_condition_type(entry.name, entry.func, entry.prototype, entry.pretty_prototype, default_event_table[entry.event_index]);
     }
 
-    ++times_loaded;
-
 }
 
 
 //Cleans up after this module.
 static void __attribute__((destructor)) uninit_module() {
-
-    --times_loaded;
-    if (times_loaded > 0)
-        return;
 
     free(default_event_table);
 }

--- a/xcpmd/src/default.rules
+++ b/xcpmd/src/default.rules
@@ -1,0 +1,22 @@
+# Default set of rules for XCPMD. These are only loaded when no rules or vars
+# exist in the DB.
+
+# Variable section
+battCritical(10)
+criticalBrightness(60)
+brightnessOnBatt(75)
+brightnessOnAc(100)
+
+# Surfman controls the backlight, and it is restricted to 15 brightness steps.
+# The backlight step will effectively be rounded to the nearest surfman step.
+backlightStep(7)
+
+# Section separator
+=
+
+# Rules section
+lidScreenPower | whileLidClosed() | screenOff() | screenOn()
+dimScreenCritical | whileUsingBatt() whileOverallBattLessThan($battCritical) | setBacklight($criticalBrightness) | setBacklight($brightnessOnAc)
+dimScreenOnBatt | whileUsingBatt() | setBacklight($brightnessOnBatt) | setBacklight($brightnessOnAc)
+brightnessUpKey | onBacklightUpBtn() | increaseBacklight($backlightStep)
+brightnessDownKey | onBacklightDownBtn() | decreaseBacklight($backlightStep)

--- a/xcpmd/src/modules.c
+++ b/xcpmd/src/modules.c
@@ -315,3 +315,14 @@ int load_policy_from_file(char * filename) {
     return 0;
 }
 
+
+//Checks if any rules or variables have yet been added.
+bool policy_exists(void) {
+
+    if (list_empty(&rules.list) && list_empty(&db_vars.list)) {
+        return false;
+    }
+    else {
+        return true;
+    }
+}

--- a/xcpmd/src/modules.c
+++ b/xcpmd/src/modules.c
@@ -306,7 +306,7 @@ int load_policy_from_db() {
 //See parser.c for information on policy file format.
 int load_policy_from_file(char * filename) {
 
-    if (!parse_config_from_file(filename))
+    if (parse_config_from_file(filename) == -1)
         return -1;
 
     write_db_rules();

--- a/xcpmd/src/modules.c
+++ b/xcpmd/src/modules.c
@@ -47,7 +47,8 @@ static char * _module_list[] = {
     MODULE_PATH "acpi-module.so",
     MODULE_PATH "vm-actions-module.so",
     MODULE_PATH "default-actions-module.so",
-    MODULE_PATH "vm-events-module.so"
+    MODULE_PATH "vm-events-module.so",
+    MODULE_PATH "screen-module.so"
 };
 
 

--- a/xcpmd/src/modules.c
+++ b/xcpmd/src/modules.c
@@ -210,7 +210,7 @@ void handle_events(struct ev_wrapper * event) {
 
         list_for_each_entry(node, &(event->listeners.list), list) {
             condition = node->condition;
-            condition->is_true = condition->type->check(event, &condition->args);
+            condition->is_true = false;
         }
     }
 

--- a/xcpmd/src/modules.h
+++ b/xcpmd/src/modules.h
@@ -40,4 +40,6 @@ int load_policy_from_db();
 int load_policy_from_file(char * filename);
 void evaluate_policy();
 
+bool policy_exists();
+
 #endif

--- a/xcpmd/src/parser.c
+++ b/xcpmd/src/parser.c
@@ -1869,6 +1869,7 @@ int parse_config_from_file(char * filename) {
     char *ptr, *token_start, *token_end, *string_end;
     bool in_var_section = true;
     bool in_quotes;
+    bool whitespace_line;
 
     memset(&data, 0, sizeof(struct parse_data));
     memset(&var_map, 0, sizeof(struct var_map));
@@ -1888,10 +1889,26 @@ int parse_config_from_file(char * filename) {
     while (fgets(line, 1024, file)) {
 
         line_no++;
+        xcpmd_log(LOG_DEBUG, "Parsing line %d: %s", line_no, line);
 
         //Discard any line beginning with a comment character (#).
         if (line[0] == '#')
             continue;
+
+        //Discard any lines containing only whitespace.
+        whitespace_line = false;
+        ptr = line;
+        while (*ptr <= ' ') {
+            if (*ptr == '\0') {
+                whitespace_line = true;
+                break;
+            }
+            ++ptr;
+        }
+        if (whitespace_line) {
+            xcpmd_log(LOG_DEBUG, "Line %d was whitespace.", line_no);
+            continue;
+        }
 
         //Discard any lines longer than 1024 characters.
         if (strchr(line, '\n') == NULL) {
@@ -1952,7 +1969,6 @@ int parse_config_from_file(char * filename) {
                 }
                 ptr += sizeof(char);
             }
-
 
             init_parse_data(&data, &var_map, data.start_state, name, NULL, conditions, actions, undos, TYPE_RULE);
             if (!parse(&data, data.conditions_str)) {

--- a/xcpmd/src/prototypes.h
+++ b/xcpmd/src/prototypes.h
@@ -20,7 +20,6 @@
 
 /* acpi-events.c */
 int xcpmd_process_input(int input_value);
-void adjust_brightness(int increase, int force);
 int get_ac_adapter_status(void);
 int get_lid_status(void);
 int acpi_events_initialize(void);

--- a/xcpmd/src/rules.c
+++ b/xcpmd/src/rules.c
@@ -1115,7 +1115,7 @@ char * rule_to_string(struct rule * rule) {
 
     if (!list_empty(&rule->undos.list)) {
         safe_str_append(&out, "| ");
-        list_for_each_entry(action, &(rule->actions.list), list) {
+        list_for_each_entry(action, &(rule->undos.list), list) {
             safe_str_append(&out, "%s(", action->type->name);
             list_for_each_entry(arg, &(action->args.list), list) {
                 tmp = arg_to_string(arg->type, arg->arg);

--- a/xcpmd/src/screen-module.c
+++ b/xcpmd/src/screen-module.c
@@ -1,0 +1,320 @@
+/*
+ * screen-module.c
+ *
+ * XCPMD module that provides display power management actions.
+ *
+ * Copyright (c) 2015 Assured Information Security, Inc.
+ *
+ * Author:
+ * Jennifer Temkin <temkinj@ainfosec.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "project.h"
+#include "xcpmd.h"
+#include "rpcgen/surfman_client.h"
+#include "rules.h"
+#include <math.h>
+
+//Function prototypes
+void screen_on(struct arg_node * args);
+void screen_off(struct arg_node * args);
+void set_backlight(struct arg_node * args);
+void increase_backlight(struct arg_node * args);
+void decrease_backlight(struct arg_node * args);
+static int get_brightness(void);
+static int get_raw_brightness(int *brightness, int *max_brightness);
+static void set_brightness(int percentage);
+
+
+//Private data structures
+struct action_table_row {
+    char * name;
+    void (* func)(struct arg_node *);
+    char * prototype;
+    char * pretty_prototype;
+};
+
+
+//Private data
+static struct action_table_row action_table[] = {
+    {"screenOn"          , screen_on          , "n" , "void"                    } ,
+    {"screenOff"         , screen_off         , "n" , "void"                    } ,
+    {"setBacklight"      , set_backlight      , "i" , "int backlight_percent"   } ,
+    {"increaseBacklight" , increase_backlight , "i" , "int percent_to_increase" } ,
+    {"decreaseBacklight" , decrease_backlight , "i" , "int percent_to_decrease" }
+};
+
+static unsigned int num_action_types = sizeof(action_table) / sizeof(action_table[0]);
+static int times_loaded = 0;
+
+
+//Registers this module's action types.
+//The constructor attribute causes this function to run at load (dlopen()) time.
+__attribute__ ((constructor)) static void init_module() {
+
+    unsigned int i;
+
+    if (times_loaded > 0)
+        return;
+
+    for (i=0; i < num_action_types; ++i) {
+        add_action_type(action_table[i].name, action_table[i].func, action_table[i].prototype, action_table[i].pretty_prototype);
+    }
+}
+
+
+//Cleans up after this module.
+//The destructor attribute causes this to run at unload (dlclose()) time.
+__attribute__ ((destructor)) static void uninit_module() {
+
+    --times_loaded;
+
+    //if (times_loaded > 0)
+    //    return;
+
+    return;
+}
+
+
+//Actions
+//Turns all screens on.
+void screen_on(struct arg_node * args) {
+    com_citrix_xenclient_surfman_dpms_on_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
+}
+
+
+//Turns all screens off.
+void screen_off(struct arg_node * args) {
+    com_citrix_xenclient_surfman_dpms_off_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
+}
+
+
+//Sets the backlight to as close to the desired percentage as surfman allows.
+void set_backlight(struct arg_node * args) {
+
+    struct arg_node * node = get_arg(args, 0);
+    set_brightness(node->arg.i);
+}
+
+
+//Increases the backlight by as close to the current percentage as surfman allows.
+void increase_backlight(struct arg_node * args) {
+
+    struct arg_node * node = get_arg(args, 0);
+    int old_backlight, new_backlight;
+
+    old_backlight = get_brightness();
+    if (old_backlight < 0) {
+        return;
+    }
+
+    new_backlight = old_backlight + node->arg.i;
+
+    if (new_backlight > 100) {
+        new_backlight = 100;
+    }
+    else if (new_backlight < old_backlight) {
+        new_backlight = old_backlight;
+    }
+
+    set_brightness(new_backlight);
+}
+
+
+//Increases the backlight by as close to the current percentage as surfman allows.
+void decrease_backlight(struct arg_node * args) {
+
+    struct arg_node * node = get_arg(args, 0);
+    int old_backlight, new_backlight;
+
+    old_backlight = get_brightness();
+    if (old_backlight < 0) {
+        return;
+    }
+
+    new_backlight = old_backlight - node->arg.i;
+
+    if (new_backlight < 0) {
+        new_backlight = 0;
+    }
+    else if (new_backlight > old_backlight) {
+        new_backlight = old_backlight;
+    }
+
+    set_brightness(new_backlight);
+}
+
+
+//Get the raw backlight values.
+static int get_raw_brightness(int * brightness, int * max_brightness) {
+
+    DIR *sys_dir = NULL;
+    struct dirent * dp;
+    FILE * file = NULL;
+    char data[128];
+    char *device_name = NULL, *path = NULL;
+
+    if (brightness == NULL && max_brightness == NULL) {
+        xcpmd_log(LOG_DEBUG, "get_brightness called with null args?");
+        goto fail;
+    }
+
+    //Get the backlight directory.
+    sys_dir = opendir(BACKLIGHT_PATH);
+    if (!sys_dir) {
+        xcpmd_log(LOG_WARNING, "Couldn't open backlight dir %s - error %d\n", BACKLIGHT_PATH, errno);
+        goto fail;
+    }
+
+    //There can be more than one backlight device, and the names of these
+    //devices may vary from platform to platform. They should all report
+    //correct values, so just choose the first one.
+    while ((dp = readdir(sys_dir)) != NULL) {
+        if (dp->d_type == DT_LNK) {
+            device_name = clone_string(dp->d_name);
+            break;
+        }
+    }
+    if (device_name == NULL) {
+        xcpmd_log(LOG_WARNING, "No backlight devices found in %s\n", BACKLIGHT_PATH);
+        goto fail;
+    }
+    closedir(sys_dir);
+    sys_dir = NULL;
+
+    //Get the current brightness and max brightness.
+    if (brightness != NULL) {
+        path = safe_sprintf("%s/%s/%s", BACKLIGHT_PATH, device_name, "actual_brightness");
+        file = fopen(path, "r");
+        if (file == NULL) {
+            xcpmd_log(LOG_WARNING, "Couldn't open file %s - error %d\n", path, errno);
+            goto fail;
+        }
+
+        fgets(data, sizeof(data), file);
+        *brightness = atoi(data);
+        fclose(file);
+        free(path);
+        file = NULL;
+        path = NULL;
+    }
+
+    if (max_brightness != NULL) {
+        path = safe_sprintf("%s/%s/%s", BACKLIGHT_PATH, device_name, "max_brightness");
+        file = fopen(path, "r");
+        if (file == NULL) {
+            xcpmd_log(LOG_WARNING, "Couldn't open file %s - error %d\n", path, errno);
+            goto fail;
+        }
+    
+        fgets(data, sizeof(data), file);
+        *max_brightness = atoi(data);
+        fclose(file);
+        free(path);
+        file = NULL;
+        path = NULL;
+    }
+    free(device_name);
+    device_name = NULL;
+
+    return 0;
+
+fail:
+
+    if (sys_dir) {
+        closedir(sys_dir);
+    }
+
+    if (file) {
+        fclose(file);
+    }
+
+    if (path) {
+        free(path);
+    }
+
+    if (device_name) {
+        free(device_name);
+    }
+
+    return -1;
+}
+
+
+//Get the current backlight value in percent.
+static int get_brightness(void) {
+    
+    int brightness, max_brightness, percent;
+
+    if (get_raw_brightness(&brightness, &max_brightness) != 0)
+        return -1;
+
+    //Convert backlight to percent.
+    if (max_brightness == 0) {
+        percent = 0;
+    }
+    else {
+        percent = (brightness * 100) / max_brightness;
+    }
+
+    return percent;
+}
+
+
+//Surfman doesn't have a method to set this directly, so we have to do it the
+//roundabout way.
+static void set_brightness(int percent) {
+
+    int brightness, max_brightness, desired_brightness;
+    int surfman_step_size, desired_steps, current_steps, steps_to_take;
+    int i;
+
+    if (get_raw_brightness(&brightness, &max_brightness) != 0) {
+        xcpmd_log(LOG_WARNING, "Couldn't set brightness; unable to read current brightness.");
+        return;
+    }
+
+    //Surfman currently supports 15 levels of brightness. Get the step size.
+    surfman_step_size = max_brightness / 15;
+
+    //Bounds-check our requested brightness.
+    if (percent > 100) {
+        percent = 100;
+    }
+    else if (percent < 0) {
+        percent = 0;
+    }
+
+    //Determine the desired brightness.
+    desired_brightness = (percent * max_brightness) / 100;
+
+    //Determine how many times we'll need to ask surfman to change the brightness.
+    current_steps = brightness / surfman_step_size;
+    desired_steps = round((float)desired_brightness / (float)surfman_step_size);
+    steps_to_take = desired_steps - current_steps;
+
+    //Adjust brightness.
+    if (steps_to_take > 0) {
+        for (i = 0; i < steps_to_take; ++i) {
+            com_citrix_xenclient_surfman_increase_brightness_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
+        }
+    }
+    else if (steps_to_take < 0) {
+        for (i = 0; i > steps_to_take; --i) {
+            com_citrix_xenclient_surfman_decrease_brightness_(xcdbus_conn, SURFMAN_SERVICE, SURFMAN_PATH);
+        }
+    }
+}

--- a/xcpmd/src/screen-module.c
+++ b/xcpmd/src/screen-module.c
@@ -58,7 +58,6 @@ static struct action_table_row action_table[] = {
 };
 
 static unsigned int num_action_types = sizeof(action_table) / sizeof(action_table[0]);
-static int times_loaded = 0;
 
 
 //Registers this module's action types.
@@ -66,9 +65,6 @@ static int times_loaded = 0;
 __attribute__ ((constructor)) static void init_module() {
 
     unsigned int i;
-
-    if (times_loaded > 0)
-        return;
 
     for (i=0; i < num_action_types; ++i) {
         add_action_type(action_table[i].name, action_table[i].func, action_table[i].prototype, action_table[i].pretty_prototype);
@@ -79,11 +75,6 @@ __attribute__ ((constructor)) static void init_module() {
 //Cleans up after this module.
 //The destructor attribute causes this to run at unload (dlclose()) time.
 __attribute__ ((destructor)) static void uninit_module() {
-
-    --times_loaded;
-
-    //if (times_loaded > 0)
-    //    return;
 
     return;
 }

--- a/xcpmd/src/vm-actions-module.c
+++ b/xcpmd/src/vm-actions-module.c
@@ -578,8 +578,9 @@ void shutdown_dependencies_of_vm(char * vm_path, char * vm_type) {
 
         deps_list_entry->vm_path = clone_string(vm_identifier_table->entries[i].path);
 
+        //Property_get_* returns an alloc'd string, so don't bother cloning it.
         property_get_com_citrix_xenclient_xenmgr_vm_state_(xcdbus_conn, XENMGR_SERVICE, vm_identifier_table->entries[i].path, &state);
-        deps_list_entry->vm_state = clone_string(state);
+        deps_list_entry->vm_state = state;
 
         //get_vm_type returns an alloc'd string, so don't bother cloning it.
         get_vm_type(vm_identifier_table->entries[i].path, &type);
@@ -587,6 +588,7 @@ void shutdown_dependencies_of_vm(char * vm_path, char * vm_type) {
 
         get_vm_dependencies(deps_list_entry->vm_path, &tmp);
         deps_list_entry->deps = new_vm_identifier_table(tmp);
+        g_ptr_array_free(tmp, TRUE);
     }
 
     //Add all dependencies of the vm to a jeopardy list.
@@ -808,6 +810,7 @@ void shutdown_vpnvm_dependencies (struct arg_node * args) {
         }
 
         free(paths[i]);
+        free(state);
     }
 
     free(paths);

--- a/xcpmd/src/vm-actions-module.c
+++ b/xcpmd/src/vm-actions-module.c
@@ -81,6 +81,7 @@ struct vm_deps {
     struct list_head list;
     char * vm_path;
     char * vm_state;
+    char * vm_type;
     struct vm_identifier_table * deps;
 };
 
@@ -478,7 +479,7 @@ static void gather_dependencies(char * vm_to_check, struct vm_deps * master_deps
                     flat_list_entry = (struct vm_list *)malloc(sizeof(struct vm_list));
                     flat_list_entry->vm_path = clone_string(vm_with_deps->deps->entries[i].path);
                     list_add_tail(&flat_list_entry->list, &flat_list->list);
-                    //xcpmd_log(LOG_DEBUG, "Adding %s to jeopardy list.", flat_list_entry->vm_path);
+                    xcpmd_log(LOG_DEBUG, "Adding %s to jeopardy list.", flat_list_entry->vm_path);
                     ++depth;
                     gather_dependencies(flat_list_entry->vm_path, master_deps, flat_list);
                     --depth;
@@ -493,10 +494,10 @@ static void gather_dependencies(char * vm_to_check, struct vm_deps * master_deps
 //Optionally, provide a type to shut down only dependencies of that type.
 //Does not attempt to shut down VMs that are already stopping/stopped, or
 //any VMs that are still depended on by other VMs.
-void shutdown_dependencies_of_vm(char * vm_path, char * type) {
+void shutdown_dependencies_of_vm(char * vm_path, char * vm_type) {
 
     GPtrArray * tmp;
-    char * state;
+    char * state, *type;
     struct vm_identifier_table * safe_entry_deps = NULL;
     unsigned int i;
 
@@ -515,7 +516,7 @@ void shutdown_dependencies_of_vm(char * vm_path, char * type) {
     INIT_LIST_HEAD(&safe.list);
     INIT_LIST_HEAD(&jeopardy.list);
 
-    //Cache master list of vms and their state and dependencies.
+    //Cache master list of vms and their state, type, and dependencies.
     for (i=0; i < vm_identifier_table->num_entries; ++i) {
 
         deps_list_entry = (struct vm_deps *)malloc(sizeof(struct vm_deps));
@@ -525,6 +526,10 @@ void shutdown_dependencies_of_vm(char * vm_path, char * type) {
 
         property_get_com_citrix_xenclient_xenmgr_vm_state_(xcdbus_conn, XENMGR_SERVICE, vm_identifier_table->entries[i].path, &state);
         deps_list_entry->vm_state = clone_string(state);
+
+        //get_vm_type returns an alloc'd string, so don't bother cloning it.
+        get_vm_type(vm_identifier_table->entries[i].path, &type);
+        deps_list_entry->vm_type = type;
 
         get_vm_dependencies(deps_list_entry->vm_path, &tmp);
         deps_list_entry->deps = new_vm_identifier_table(tmp);
@@ -543,42 +548,64 @@ void shutdown_dependencies_of_vm(char * vm_path, char * type) {
             free_vm_identifier_table(deps_list_entry->deps);
             free(deps_list_entry->vm_path);
             free(deps_list_entry->vm_state);
+            free(deps_list_entry->vm_type);
             free(deps_list_entry);
         }
         return;
     }
 
-    //Generate the complement of the jeopardy list, the safe list.
+    //Generate the safe list, a set of VMs who must not shut down and whose
+    //dependencies will also be added to the safe list.
+
+    //Iterate over all VMs.
     list_for_each_entry(deps_list_entry, &vm_deps_list.list, list) {
 
-        //But omit the VM who this function was called on.
+        //Skip the VM who this function was called on.
         if (!strcmp(vm_path, deps_list_entry->vm_path)) {
             continue;
         }
 
-        //Also omit VMs who are stopping/stopped.
+        //Also skip VMs who are stopping/stopped.
         if (!strcmp(deps_list_entry->vm_state, "stopping") || !strcmp(deps_list_entry->vm_state, "stopped")) {
-            //xcpmd_log(LOG_DEBUG, "Omitting %s from safe list, since it's %s.", deps_list_entry->vm_path, deps_list_entry->vm_state);
+            xcpmd_log(LOG_DEBUG, "Omitting %s from safe list, since it's %s.", deps_list_entry->vm_path, deps_list_entry->vm_state);
             continue;
         }
 
+        //Iterate over the jeopardy list and see if this VM is on it.
         bool in_jeopardy = false;
-        list_for_each_entry(jeopardy_list_entry, &jeopardy.list, list) {
+        list_for_each_entry_safe(jeopardy_list_entry, vm_list_ptr, &jeopardy.list, list) {
+
+            //If it is...
             if (!strcmp(jeopardy_list_entry->vm_path, deps_list_entry->vm_path)) {
-                in_jeopardy = true;
+                
+                //...check its type--if it doesn't match the desired
+                //type, it doesn't belong on the jeopardy list.
+                if (vm_type && strcmp(deps_list_entry->vm_type, vm_type)) {
+                    list_del(&jeopardy_list_entry->list);
+                    free(jeopardy_list_entry->vm_path);
+                    free(jeopardy_list_entry);
+                    xcpmd_log(LOG_DEBUG, "Removing %s from jeopardy list, since its type is %s.", safe_list_entry->vm_path, deps_list_entry->vm_type);
+                }
+                else {
+                    in_jeopardy = true;
+                }
+
                 break;
             }
         }
 
+        //If this VM isn't on the jeopardy list, it belongs on the safe list.
         if (!in_jeopardy) {
             safe_list_entry = (struct vm_list *)malloc(sizeof(struct vm_list));
             safe_list_entry->vm_path = clone_string(deps_list_entry->vm_path);
             list_add_tail(&safe_list_entry->list, &safe.list);
-            //xcpmd_log(LOG_DEBUG, "Adding %s to safe list.", safe_list_entry->vm_path);
+            xcpmd_log(LOG_DEBUG, "Adding %s to safe list.", safe_list_entry->vm_path);
         }
     }
 
     //Does any VM in the safe list depend on any VM in the jeopardy list?
+    //Tail-adding entries to the safe list as we iterate allows us to map the
+    //entire dependency cone with just one loop.
     list_for_each_entry(safe_list_entry, &safe.list, list) {
 
         //Find the safe_list_entry's dependencies
@@ -601,7 +628,7 @@ void shutdown_dependencies_of_vm(char * vm_path, char * type) {
                 if (!strcmp(safe_entry_deps->entries[i].path, jeopardy_list_entry->vm_path)) {
                     list_del(&jeopardy_list_entry->list);
                     list_add_tail(&jeopardy_list_entry->list, &safe.list);
-                    //xcpmd_log(LOG_DEBUG, "Moving %s from jeopardy list to safe list, since %s depends on it", jeopardy_list_entry->vm_path, safe_list_entry->vm_path);
+                    xcpmd_log(LOG_DEBUG, "Moving %s from jeopardy list to safe list, since %s depends on it", jeopardy_list_entry->vm_path, safe_list_entry->vm_path);
                     break;
                 }
             }
@@ -613,6 +640,7 @@ void shutdown_dependencies_of_vm(char * vm_path, char * type) {
 
         xcpmd_log(LOG_DEBUG, "Shutting down %s.", jeopardy_list_entry->vm_path);
         shutdown_vm_async(jeopardy_list_entry->vm_path);
+
         list_del(&jeopardy_list_entry->list);
         free(jeopardy_list_entry->vm_path);
         free(jeopardy_list_entry);
@@ -631,6 +659,7 @@ void shutdown_dependencies_of_vm(char * vm_path, char * type) {
         free_vm_identifier_table(deps_list_entry->deps);
         free(deps_list_entry->vm_path);
         free(deps_list_entry->vm_state);
+        free(deps_list_entry->vm_type);
         free(deps_list_entry);
     }
 }

--- a/xcpmd/src/vm-actions-module.c
+++ b/xcpmd/src/vm-actions-module.c
@@ -137,7 +137,10 @@ __attribute__ ((destructor)) static void uninit_module() {
 void sleep_vm(struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_name(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to sleep vm %s--couldn't get UUID\n", node->arg.str);
@@ -153,7 +156,10 @@ void sleep_vm(struct arg_node * args) {
 void resume_vm(struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_name(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to resume vm %s--couldn't get UUID\n", node->arg.str);
@@ -169,7 +175,10 @@ void resume_vm(struct arg_node * args) {
 void pause_vm(struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_name(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to pause vm %s--couldn't get UUID\n", node->arg.str);
@@ -185,7 +194,10 @@ void pause_vm(struct arg_node * args) {
 void unpause_vm(struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_name(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to unpause vm %s--couldn't get UUID\n", node->arg.str);
@@ -201,7 +213,10 @@ void unpause_vm(struct arg_node * args) {
 void reboot_vm(struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_name(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to reboot vm %s--couldn't get UUID\n", node->arg.str);
@@ -217,7 +232,10 @@ void reboot_vm(struct arg_node * args) {
 void shutdown_vm(struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_name(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to shutdown vm %s--couldn't get UUID\n", node->arg.str);
@@ -233,7 +251,10 @@ void shutdown_vm(struct arg_node * args) {
 void start_vm(struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_name(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to start vm %s--couldn't get UUID\n", node->arg.str);
@@ -249,7 +270,10 @@ void start_vm(struct arg_node * args) {
 void suspend_vm_to_file(struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_name(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to suspend vm %s to file--couldn't get UUID\n", node->arg.str);
@@ -268,7 +292,10 @@ void suspend_vm_to_file(struct arg_node * args) {
 void resume_vm_from_file(struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_name(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to resume vm %s from file--couldn't get UUID\n", node->arg.str);
@@ -287,7 +314,10 @@ void resume_vm_from_file(struct arg_node * args) {
 void sleep_vm_by_uuid (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_uuid(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_uuid(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to sleep vm--couldn't get xenstore path\n");
@@ -303,7 +333,10 @@ void sleep_vm_by_uuid (struct arg_node * args) {
 void resume_vm_by_uuid (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_uuid(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_uuid(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to resume vm--couldn't get xenstore path\n");
@@ -319,7 +352,10 @@ void resume_vm_by_uuid (struct arg_node * args) {
 void pause_vm_by_uuid (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_uuid(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_uuid(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to pause vm--couldn't get xenstore path\n");
@@ -335,7 +371,10 @@ void pause_vm_by_uuid (struct arg_node * args) {
 void unpause_vm_by_uuid (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_uuid(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_uuid(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to unpause vm--couldn't get xenstore path\n");
@@ -351,7 +390,10 @@ void unpause_vm_by_uuid (struct arg_node * args) {
 void reboot_vm_by_uuid (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_uuid(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_uuid(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to reboot vm--couldn't get xenstore path\n");
@@ -367,7 +409,10 @@ void reboot_vm_by_uuid (struct arg_node * args) {
 void shutdown_vm_by_uuid (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_uuid(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_uuid(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to shutdown vm--couldn't get xenstore path\n");
@@ -385,7 +430,10 @@ void shutdown_vm_by_uuid (struct arg_node * args) {
 void start_vm_by_uuid (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_uuid(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_uuid(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to start vm--couldn't get xenstore path\n");
@@ -403,7 +451,10 @@ void start_vm_by_uuid (struct arg_node * args) {
 void suspend_vm_by_uuid_to_file (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_uuid(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_uuid(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to shutdown vm--couldn't get xenstore path\n");
@@ -424,7 +475,10 @@ void suspend_vm_by_uuid_to_file (struct arg_node * args) {
 void resume_vm_by_uuid_from_file (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_uuid(node->arg.str);
+    struct vm_identifier_table_row * vmid;
+
+    populate_vm_identifier_table();
+    vmid = new_vmid_search_result_by_uuid(node->arg.str);
 
     if ((!vmid) || (!(vmid->path))) {
         xcpmd_log(LOG_WARNING, "Failed to shutdown vm--couldn't get xenstore path\n");
@@ -577,7 +631,7 @@ void shutdown_dependencies_of_vm(char * vm_path, char * vm_type) {
 
             //If it is...
             if (!strcmp(jeopardy_list_entry->vm_path, deps_list_entry->vm_path)) {
-                
+
                 //...check its type--if it doesn't match the desired
                 //type, it doesn't belong on the jeopardy list.
                 if (vm_type && strcmp(deps_list_entry->vm_type, vm_type)) {
@@ -668,9 +722,11 @@ void shutdown_dependencies_of_vm(char * vm_path, char * vm_type) {
 void shutdown_dependencies_of_vm_by_name (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
 
+    populate_vm_identifier_table();
     vmid = new_vmid_search_result_by_name(node->arg.str);
+
     if (vmid && vmid->path) {
         shutdown_dependencies_of_vm(vmid->path, NULL);
     }
@@ -681,9 +737,11 @@ void shutdown_dependencies_of_vm_by_name (struct arg_node * args) {
 void shutdown_dependencies_of_vm_by_uuid (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
 
+    populate_vm_identifier_table();
     vmid = new_vmid_search_result_by_uuid(node->arg.str);
+
     if (vmid && vmid->path) {
         shutdown_dependencies_of_vm(vmid->path, NULL);
     }
@@ -694,9 +752,11 @@ void shutdown_dependencies_of_vm_by_uuid (struct arg_node * args) {
 void shutdown_vpnvm_dependencies_of_vm_by_name (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
 
+    populate_vm_identifier_table();
     vmid = new_vmid_search_result_by_name(node->arg.str);
+
     if (vmid && vmid->path) {
         shutdown_dependencies_of_vm(vmid->path, "vpnvm");
     }
@@ -707,9 +767,11 @@ void shutdown_vpnvm_dependencies_of_vm_by_name (struct arg_node * args) {
 void shutdown_vpnvm_dependencies_of_vm_by_uuid (struct arg_node * args) {
 
     struct arg_node * node = get_arg(args, 0);
-    struct vm_identifier_table_row * vmid = new_vmid_search_result_by_name(node->arg.str);
+    struct vm_identifier_table_row * vmid;
 
+    populate_vm_identifier_table();
     vmid = new_vmid_search_result_by_uuid(node->arg.str);
+
     if (vmid && vmid->path) {
         shutdown_dependencies_of_vm(vmid->path, "vpnvm");
     }
@@ -733,7 +795,7 @@ void shutdown_vpnvm_dependencies (struct arg_node * args) {
     //VM identifier table out from under us.
     num_vms = vm_identifier_table->num_entries;
     paths = (char **)malloc(num_vms * sizeof(char *));
-    
+
     for (i=0; i < num_vms; ++i) {
         paths[i] = clone_string(vm_identifier_table->entries[i].path);
     }

--- a/xcpmd/src/vm-events-module.c
+++ b/xcpmd/src/vm-events-module.c
@@ -111,8 +111,6 @@ static struct cond_table_row condition_data[] = {
 static unsigned int num_events = sizeof(event_data) / sizeof(event_data[0]);
 static unsigned int num_conditions = sizeof(condition_data) / sizeof(condition_data[0]);
 
-static int times_loaded = 0;
-
 
 //Public data
 struct ev_wrapper ** _vm_event_table;
@@ -121,9 +119,6 @@ struct ev_wrapper ** _vm_event_table;
 //Initializes the module.
 //The constructor attribute causes this function to run at load (dlopen()) time.
 __attribute__((constructor)) static void init_module() {
-
-    if (times_loaded > 0)
-        return;
 
     unsigned int i;
 
@@ -148,18 +143,12 @@ __attribute__((constructor)) static void init_module() {
 
     //Set up a match and filter to get signals.
     add_dbus_filter("type='signal',interface='com.citrix.xenclient.xenmgr',member='vm_state_changed'", dbus_signal_handler, NULL, NULL);
-
-    ++times_loaded;
 }
 
 
 //Cleans up after this module.
 //The destructor attribute causes this to run at unload (dlclose()) time.
 __attribute__((destructor)) static void uninit_module() {
-
-    --times_loaded;
-    if (times_loaded > 0)
-        return;
 
     //Free event tables.
     free(_vm_event_table);

--- a/xcpmd/src/vm-utils.c
+++ b/xcpmd/src/vm-utils.c
@@ -65,7 +65,7 @@ void populate_vm_identifier_table() {
 struct vm_identifier_table * new_vm_identifier_table(GPtrArray * vm_list) {
 
     struct vm_identifier_table * table;
-    char * tmp;
+    char * tmp = NULL;
     char * vm;
     unsigned int i;
 
@@ -93,24 +93,23 @@ struct vm_identifier_table * new_vm_identifier_table(GPtrArray * vm_list) {
         property_get_com_citrix_xenclient_xenmgr_vm_name_(xcdbus_conn, XENMGR_SERVICE, vm, &tmp);
         if(tmp == NULL) {
             xcpmd_log(LOG_ERR, "Error: Couldn't get name of %s.\n", vm);
-            free_vm_identifier_table(table);
-            return NULL;
+            goto fail;
         }
 
         table->entries[i].name = (char *)malloc(strlen(tmp) + 1);
         if (table->entries[i].name == NULL) {
             xcpmd_log(LOG_ERR, "Failed to allocate memory\n");
-            free_vm_identifier_table(table);
-            return NULL;
+            goto fail;
         }
         strcpy(table->entries[i].name, tmp);
+        free(tmp);
+        tmp = NULL;
 
         //Copy the VM path.
         table->entries[i].path = (char *)malloc(VM_PATH_LEN + 1); //path_len = 40 = 32 path bytes + 4 underscores + "/vm/" (4), and 1 byte for \0
         if (table->entries[i].path == NULL) {
             xcpmd_log(LOG_ERR, "Failed to allocate memory\n");
-            free_vm_identifier_table(table);
-            return NULL;
+            goto fail;
         }
         strncpy(table->entries[i].path, vm, VM_PATH_LEN + 1);
 
@@ -118,8 +117,7 @@ struct vm_identifier_table * new_vm_identifier_table(GPtrArray * vm_list) {
         table->entries[i].uuid = (char *)malloc(VM_PATH_LEN - VM_PATH_UUID_PREFIX_LEN + 1); //path_len = 36 = 32 path bytes + 4 hyphens, and 1 byte for \0
         if (table->entries[i].uuid == NULL) {
             xcpmd_log(LOG_ERR, "Failed to allocate memory\n");
-            free_vm_identifier_table(table);
-            return NULL;
+            goto fail;
         }
         strncpy(table->entries[i].uuid, vm+VM_PATH_UUID_PREFIX_LEN, VM_PATH_LEN - VM_PATH_UUID_PREFIX_LEN + 1);
 
@@ -134,6 +132,15 @@ struct vm_identifier_table * new_vm_identifier_table(GPtrArray * vm_list) {
     }
 
     return table;
+
+fail:
+    if (tmp) {
+        g_free(tmp);
+    }
+
+    free_vm_identifier_table(table);
+    return NULL;
+
 }
 
 
@@ -270,8 +277,9 @@ int get_vm_type(const char * vm_path, char ** type) {
     int status;
     
     status = dbus_get_property(xcdbus_conn, XENMGR_SERVICE, vm_path, XENMGR_VM_INTERFACE, "type", &gval);
-    *type = (char *)g_value_get_string(&gval);
+    *type = strdup((char *)g_value_get_string(&gval));
     xcpmd_log(LOG_DEBUG, "Type of %s is %s.\n", vm_path, *type);
+    g_value_unset(&gval);
 
     return status;
 }

--- a/xcpmd/src/vm-utils.c
+++ b/xcpmd/src/vm-utils.c
@@ -262,6 +262,21 @@ int get_vm_dependencies(const char * vm_path, GPtrArray ** ary) {
 }
 
 
+//Allocates memory!
+//Gets the type of a VM. (ndvm, vpnvm, etc)
+int get_vm_type(const char * vm_path, char ** type) {
+
+    GValue gval;
+    int status;
+    
+    status = dbus_get_property(xcdbus_conn, XENMGR_SERVICE, vm_path, XENMGR_VM_INTERFACE, "type", &gval);
+    *type = (char *)g_value_get_string(&gval);
+    xcpmd_log(LOG_DEBUG, "Type of %s is %s.\n", vm_path, *type);
+
+    return status;
+}
+
+
 //Frees all members of a vmid table row.
 void free_vm_identifier_table_row_data(struct vm_identifier_table_row * r) {
 

--- a/xcpmd/src/vm-utils.h
+++ b/xcpmd/src/vm-utils.h
@@ -56,6 +56,7 @@ struct vm_identifier_table_row * new_vmid_search_result_by_uuid(char * uuid);
 struct vm_identifier_table_row * new_vmid_search_result_by_path(char * path);
 struct vm_identifier_table_row * clone_vmid_table_row(struct vm_identifier_table_row * ir);
 int get_vm_dependencies(const char * vm_path, GPtrArray ** ary);
+int get_vm_type(const char * vm_path, char ** type);
 
 void free_vm_identifier_table_row_data(struct vm_identifier_table_row * r);
 void free_vm_identifier_table(struct vm_identifier_table * table);

--- a/xcpmd/src/xcpmd.c
+++ b/xcpmd/src/xcpmd.c
@@ -101,8 +101,11 @@ int main(int argc, char *argv[]) {
     }
 
 #ifdef POLICY_FILE_PATH
-    if (load_policy_from_file(POLICY_FILE_PATH) == -1) {
-        xcpmd_log(LOG_WARNING, "Error loading policy from file %s; continuing...\n", POLICY_FILE_PATH);
+    if (!policy_exists()) {
+        xcpmd_log(LOG_INFO, "No DB policy found; loading default policy from %s.\n", POLICY_FILE_PATH);
+        if (load_policy_from_file(POLICY_FILE_PATH) == -1) {
+            xcpmd_log(LOG_WARNING, "Error loading policy from file %s; continuing...\n", POLICY_FILE_PATH);
+        }
     }
 #endif
 

--- a/xcpmd/src/xcpmd.h
+++ b/xcpmd/src/xcpmd.h
@@ -178,6 +178,7 @@ struct battery_status {
 #define LID_DIR_PATH2                       "/proc/acpi/button/lid/LID0"
 #define LID_STATE_FILE_PATH                 LID_DIR_PATH"/state"
 #define LID_STATE_FILE_PATH2                LID_DIR_PATH2"/state"
+#define BACKLIGHT_PATH                      "/sys/class/backlight"
 #define ACPID_SOCKET_PATH                   "/var/run/acpid.socket"
 
 #define XS_FORMAT_PATH_LEN                  128

--- a/xcpmd/src/xcpmd.h
+++ b/xcpmd/src/xcpmd.h
@@ -259,4 +259,6 @@ extern uint32_t pm_specs;
 #define DB_VAR_MAP_PATH                     "/power-management/vars"
 #define DB_RULE_PATH                        "/power-management/rules"
 
+#define POLICY_FILE_PATH                    "/usr/share/xcpmd/default.rules"
+
 #endif /* __XCPMD_H__ */


### PR DESCRIPTION
Plus a bunch of relatively minor bugfixes.

The default policy here is to dim the screen when unplugged, dim it further when battery is low, dim even further when battery is critical, and restore to full brightness when plugged in; the "low" and "critical" thresholds are stored in variables and are easily adjustable. The screen will turn off (DPMS off, not just backlight) when the lid is closed, and turns on when the lid is opened. The previous brightness key behavior has been preserved and moved into the policy file as well.

The policy will be read from /usr/share/default.rules only if there is no "/power-management/rules" node in the DB; in this case, policy will be loaded from the aforementioned file and written back to the DB. If policy exists in the DB at startup, the DB policy will be loaded instead.

Requires SELinux policy and bootage update in [xenclient-oe PR318](https://github.com/OpenXT/xenclient-oe/pull/318).
