### PR TITLE
Split debug logging out from general utility output.

### DIFF
--- a/audio_helper/src/openxtdebug.h
+++ b/audio_helper/src/openxtdebug.h
@@ -61,13 +61,24 @@
 /// You should not use this directly, but instead use one of the openxt_
 /// macros.
 ///
+/// TODO the logging needs refactoring. Currently the debug logging is mixed
+/// in with the actual output from the utility. The SYSLOG_DEBUGGING_ENABLED
+/// macro is just a workaround to allow the verbose debug logging to not be
+/// sent to syslog. Debug logging and actaul output handling should be
+/// separated.
+#ifdef SYSLOG_DEBUGGING_ENABLED
+    #define syslog_debug(...) syslog(LOG_DEBUG, __VA_ARGS__)
+#else
+    #define syslog_debug(...) do {} while(0);
+#endif
+
 #ifdef SYSLOG
     #define OPENXT_ERROR(...) \
         fprintf(stderr, __VA_ARGS__); \
         syslog(LOG_ERR, __VA_ARGS__)
     #define OPENXT_DEBUG(...) \
         fprintf(stdout, __VA_ARGS__); \
-        syslog(LOG_DEBUG, __VA_ARGS__)
+        syslog_debug(__VA_ARGS__)
 #else
     #define OPENXT_ERROR(...) \
         fprintf(stderr, __VA_ARGS__)

--- a/audio_helper/src/openxtsettings.h
+++ b/audio_helper/src/openxtsettings.h
@@ -25,6 +25,7 @@
 
 #define SYSLOG
 #define DEBUGGING_ENABLED
+//#define SYSLOG_DEBUGGING_ENABLED
 #define TAG "openxt_audio_back"
 
 // The following means that we should have room for roughly 1280 samples


### PR DESCRIPTION
This is a temporary fix to quiet down the amount of tracing to syslog that
this utility does when operating normally. It really needs a logging overhaul
with many other things in OpenXT.

OXT-633

Signed-off-by: Ross Philipson philipsonr@ainfosec.com
