### PR TITLE
STABLE-6: [acpi] Lid state in XS should be 0/1 not closed/open.

### DIFF
--- a/xcpmd/src/acpi-events.c
+++ b/xcpmd/src/acpi-events.c
@@ -185,8 +185,10 @@ static void handle_lid_event(int status) {
 
     xcpmd_log(LOG_INFO, "Lid change event: %s\n", lid_status_string);
 
-    xenstore_write(lid_status == LID_CLOSED ? "closed" : "open", XS_LID_STATE_PATH);
-    xenstore_write("1", XS_LID_EVENT_PATH);
+    /* This is wrong - the QEMU code processing this does not know about "open"/"closed"
+    xenstore_write(lid_status == LID_CLOSED ? "closed" : "open", XS_LID_STATE_PATH);*/
+    xenstore_write_int(lid_status == LID_CLOSED ? 0 : 1, XS_LID_STATE_PATH);
+    xenstore_write_int(1, XS_LID_EVENT_PATH);
     //notify_com_citrix_xenclient_xcpmd_lid_changed(xcdbus_conn, XCPMD_SERVICE, XCPMD_PATH);
 
     e->value.i = lid_status;


### PR DESCRIPTION
OXT-694

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>