### PR TITLE
RFC: QMP helper events improvements

### DIFF
--- a/qmp_helper/src/qmp_helper.c
+++ b/qmp_helper/src/qmp_helper.c
@@ -338,6 +338,8 @@ int main(int argc, char *argv[])
             nfds = qhs.listen_fd > nfds ? qhs.listen_fd : nfds;
         }
         nfds += 1;
+        QMPH_LOG("pre-select argo:%d unix:%d listen:%d\n",
+                 qhs.argo_fd, qhs.unix_fd, qhs.listen_fd);
 
         if (select(nfds, &rfds, NULL, NULL, NULL) == -1) {
             ret = errno;

--- a/qmp_helper/src/qmp_helper.c
+++ b/qmp_helper/src/qmp_helper.c
@@ -155,7 +155,10 @@ static int qmph_argo_to_unix(struct qmp_helper_state *pqhs)
     if (ret < 0) {
         QMPH_LOG("ERROR write(unix_fd) failed (%s) - %d.\n",
                  strerror(errno), ret);
-        return ret;
+        QMPH_LOG("closing unix_fd - maybe client disappeared");
+        close(pqhs->unix_fd);
+        pqhs->unix_fd = -1;
+        return 0;
     }
 
     return 0;

--- a/qmp_helper/src/qmp_helper.c
+++ b/qmp_helper/src/qmp_helper.c
@@ -204,7 +204,7 @@ static int qmph_accept_unix_socket(struct qmp_helper_state *pqhs)
     socklen_t len = sizeof(un);
     int lfd, cfd;
 
-    QMPH_LOG("Waiting for connection on unix socket");
+    QMPH_LOG("Accepting connection on unix socket");
 
     lfd = pqhs->listen_fd;
 
@@ -228,7 +228,6 @@ static int qmph_init_unix_socket(struct qmp_helper_state *pqhs)
 {
     struct sockaddr_un un;
     int lfd;
-    int ret;
 
     /* By default the helper creates a Unix socket as if QEMU were called with:
      * -qmp unix:/var/run/xen/qmp-libxl-<domid>,server,nowait
@@ -261,12 +260,6 @@ static int qmph_init_unix_socket(struct qmp_helper_state *pqhs)
     }
 
     pqhs->listen_fd = lfd;
-
-    ret = qmph_accept_unix_socket(pqhs);
-    if (ret) {
-        QMPH_LOG("ERROR failed to accept unix socket - ret: %d\n", ret);
-        qmph_exit_cleanup(ret);
-    }
 
     return 0;
 
@@ -321,9 +314,6 @@ int main(int argc, char *argv[])
 
     QMPH_LOG("argo ready, wait for a connection...");
 
-    /* Ready to listen and accept one connection. Note this will block on
-     * accept until connected.
-     */
     ret = qmph_init_unix_socket(&qhs);
     if (ret) {
         QMPH_LOG("ERROR failed to init unix socket - ret: %d\n", ret);

--- a/qmp_helper/src/qmp_helper.c
+++ b/qmp_helper/src/qmp_helper.c
@@ -146,6 +146,11 @@ static int qmph_argo_to_unix(struct qmp_helper_state *pqhs)
         return rcv;
     }
 
+    if (pqhs->unix_fd == -1) {
+        QMPH_LOG("Dropping argo message '%.*s'", rcv, pqhs->msg_buf);
+        return 0;
+    }
+
     ret = write(pqhs->unix_fd, pqhs->msg_buf, rcv);
     if (ret < 0) {
         QMPH_LOG("ERROR write(unix_fd) failed (%s) - %d.\n",

--- a/qmp_helper/src/qmp_helper.c
+++ b/qmp_helper/src/qmp_helper.c
@@ -47,8 +47,8 @@
  */
 #define QMPH_LOG(fmt, ...)                                           \
 do {                                                                 \
-        syslog(LOG_NOTICE, "qmp-helper [%s:%s:%d] (stubdom-%d) " fmt,\
-               __FILE__, __FUNCTION__, __LINE__, qhs.stubdom_id,     \
+        syslog(LOG_NOTICE, "qmp-helper [%s:%d] (stubdom-%d) " fmt,   \
+               __FUNCTION__, __LINE__, qhs.stubdom_id,               \
                  ##__VA_ARGS__);                                     \
     } while (0)
 


### PR DESCRIPTION
This is more a defense in depth change to go along with https://github.com/OpenXT/xenclient-oe/pull/1273

If you don't apply https://github.com/OpenXT/xenclient-oe/pull/1273 you can see qmp_helper printing the dropped messages.

RFC for now.  https://github.com/OpenXT/xctools/commit/114bb1bf33fe4efcb6789fae9240f8750a18d4a4 is useful for testing but maybe not suitable for application.  Also we may want to remove printing of the dropped messages.  Though we won't see any if https://github.com/OpenXT/xenclient-oe/pull/1273 is dropping them.