### PR TITLE
OXT-1707: xcpmd: GCC9 warnings.

### DIFF
--- a/xcpmd/src/battery.c
+++ b/xcpmd/src/battery.c
@@ -159,7 +159,7 @@ static long get_total_charge_rate(void) {
     for (i = 0; i < num_battery_structs_allocd; ++i) {
         if (last_status[i].present == YES) {
 
-            rate = labs(last_status[i].present_rate);
+            rate = last_status[i].present_rate;
             state = get_battery_charge_state(i);
 
             if (state == BATT_CHARGING) {
@@ -460,22 +460,22 @@ static void set_battery_info_attribute(char *attrib_name, char *attrib_value, st
         info->design_voltage = strtoull(attrib_value, NULL, 10) / 1000;
     }
     else if (!strcmp(attrib_name, "model_name")) {
-        strncpy(info->model_number, attrib_value, 32);
+        pstrcpy(info->model_number, sizeof (info->model_number), attrib_value);
     }
     else if (!strcmp(attrib_name, "serial_number")) {
-        strncpy(info->serial_number, attrib_value, 32);
+        pstrcpy(info->serial_number, sizeof (info->serial_number), attrib_value);
     }
     else if (!strcmp(attrib_name, "technology")) {
         if (strstr(attrib_value, "Li-ion"))
-            strncpy(info->battery_type, "LION\n\0", 6);
+            pstrcpy(info->battery_type, sizeof (info->battery_type), "LION\n");
         else if (strstr(attrib_value, "Li-poly"))
-            strncpy(info->battery_type, "LiP\n\0", 6);
+            pstrcpy(info->battery_type, sizeof (info->battery_type), "LiP\n");
         else
-            strncpy(info->battery_type, attrib_value, 32);
+            pstrcpy(info->battery_type, sizeof (info->battery_type), attrib_value);
         info->battery_technology = RECHARGEABLE;
     }
     else if (!strcmp(attrib_name, "manufacturer")) {
-      strncpy(info->oem_info, attrib_value, 32);
+      pstrcpy(info->oem_info, sizeof (info->oem_info), attrib_value);
     }
 }
 

--- a/xcpmd/src/parser.c
+++ b/xcpmd/src/parser.c
@@ -503,8 +503,7 @@ struct fn * new_fn(struct fn * last, //Last fn struct in the desired fn list to 
     }
 
     f = malloc(sizeof(struct fn));
-    f->name = malloc(strlen(name)+1);
-    strncpy(f->name, name, strlen(name)+1);
+    f->name = strdup(name);
     f->args = args;
     f->undo = undo;
     f->next = NULL;
@@ -1144,8 +1143,7 @@ void action_acceptArg(struct parse_data * data, char c) {
         sscanf(data->accum_arg, "%f", &(val.as_float));
         break;
     case TYPE_STR:
-        val.as_str = malloc(strlen(data->accum_arg)+1);
-        strncpy(val.as_str, data->accum_arg, strlen(data->accum_arg)+1);
+        val.as_str = strdup(data->accum_arg);
         break;
     case TYPE_BOOL:
         if (data->accum_arg[0] == 't') {
@@ -1171,8 +1169,7 @@ void action_acceptArg(struct parse_data * data, char c) {
             return;
         }
         str = data->accum_arg;
-        val.as_str = malloc(strlen(str) + 1);
-        strncpy(val.as_str, str, strlen(str) + 1);
+        val.as_str = strdup(str);
         data->arg_type = TYPE_VAR;
         break;
     case TYPE_UNDETERMINED:

--- a/xcpmd/src/prototypes.h
+++ b/xcpmd/src/prototypes.h
@@ -62,6 +62,7 @@ char * strsplit(char * str, char delim);
 char * clone_string(char * str);
 char * safe_sprintf(char * format, ...);
 void safe_str_append(char ** str1, char * format, ...);
+void pstrcpy(char *dst, int size, const char *src);
 void write_ulong_lsb_first(char *temp_val, unsigned long val);
 int file_set_blocking(int fd);
 int file_set_nonblocking(int fd);

--- a/xcpmd/src/utils.c
+++ b/xcpmd/src/utils.c
@@ -206,6 +206,23 @@ void safe_str_append(char ** str1, char * format, ...) {
     }
 }
 
+/* Copy at most @size bytes from @src in @dst, including the trailing NUL. If
+ * @src is larger than @size, @size-1 bytes are copied and NUL is appended as
+ * the last byte of @dst.
+ * Nothing is copied if @dst or @src is NULL, or if @size is 0 or less.
+ */
+void pstrcpy(char *dst, int size, const char *src)
+{
+    int i;
+
+    if (!dst || !src || size <= 0)
+        return;
+
+    for (i = 0; (i < size - 1) && src[i]; ++i)
+        dst[i] = src[i];
+    dst[i] = '\0';
+}
+
 
 void write_ulong_lsb_first(char *temp_val, unsigned long val)
 {


### PR DESCRIPTION
-Wstringop-overflow warnings.

- Add pstrcpy to replace strncpy with guaranty that the destination
buffer will be NUL terminated within its bounds.
- Replace strncpy(dst, src, strlen(src) + 1) with strdup(dst, src).

-Wabsolute-value
- labs() on unsigned long is noop.