### PR TITLE
Security flag fixes

### DIFF
--- a/audio_helper/src/main.c
+++ b/audio_helper/src/main.c
@@ -21,6 +21,7 @@
 //
 
 #include "unittest.h"
+#include "openxtalsa.h"
 #include "openxtdebug.h"
 #include "openxtvmaudio.h"
 #include "openxtmixerctl.h"

--- a/audio_helper/src/unittest.c
+++ b/audio_helper/src/unittest.c
@@ -569,8 +569,12 @@ void test_capture(void)
         if (nread <= 0)
             continue;
 
-        // Write the data.
-        write(1, buffer, nread * sizeof(int32_t));
+        // Write the data ignoring errors.
+        ret = write(1, buffer, nread * sizeof(int32_t));
+        if (ret == -1) {
+            perror("write");
+            return;
+        }
     }
 }
 

--- a/audio_helper/src/unittest.c
+++ b/audio_helper/src/unittest.c
@@ -269,7 +269,7 @@ void test_alsa(void)
     playback_settings->nchannels = 2;
     playback_settings->sample_size = sizeof(uint32_t);
     playback_settings->selement_index = 0;
-    snprintf(playback_settings->pcm_name, sizeof(playback_settings->pcm_name), getenv("ALSA_DEVICE"));
+    snprintf(playback_settings->pcm_name, sizeof(playback_settings->pcm_name), "%s", getenv("ALSA_DEVICE"));
     snprintf(playback_settings->selement_name, sizeof(playback_settings->selement_name), "Master");
 
     // Setup the capture_settings variable.
@@ -280,7 +280,7 @@ void test_alsa(void)
     capture_settings->nchannels = 2;
     capture_settings->sample_size = sizeof(uint32_t);
     capture_settings->selement_index = 0;
-    snprintf(capture_settings->pcm_name, sizeof(capture_settings->pcm_name), getenv("ALSA_DEVICE"));
+    snprintf(capture_settings->pcm_name, sizeof(capture_settings->pcm_name), "%s", getenv("ALSA_DEVICE"));
     snprintf(capture_settings->selement_name, sizeof(capture_settings->selement_name), "Capture");
 
     // Validate improper use of the init function
@@ -537,7 +537,7 @@ void test_capture(void)
     capture_settings->nchannels = 2;
     capture_settings->sample_size = sizeof(uint32_t);
     capture_settings->selement_index = 0;
-    snprintf(capture_settings->pcm_name, sizeof(capture_settings->pcm_name), getenv("ALSA_DEVICE"));
+    snprintf(capture_settings->pcm_name, sizeof(capture_settings->pcm_name), "%s", getenv("ALSA_DEVICE"));
     snprintf(capture_settings->selement_name, sizeof(capture_settings->selement_name), "Capture");
 
     // Initialize the Capture device.
@@ -599,7 +599,7 @@ void test_playback(void)
     playback_settings->nchannels = 2;
     playback_settings->sample_size = sizeof(uint32_t);
     playback_settings->selement_index = 0;
-    snprintf(playback_settings->pcm_name, sizeof(playback_settings->pcm_name), getenv("ALSA_DEVICE"));
+    snprintf(playback_settings->pcm_name, sizeof(playback_settings->pcm_name), "%s", getenv("ALSA_DEVICE"));
     snprintf(playback_settings->selement_name, sizeof(playback_settings->selement_name), "Master");
 
     // Initialize the Capture device.


### PR DESCRIPTION
Fixes for -Werror=format-security and -Werror=unused-result.

Also add the openxtalsa.h header to main.c to quiet some implicit declaration warnings.