### PR TITLE
Updates after Linux Argo header changes: OXT-1694

### DIFF
--- a/atapi_pt_helper/src/atapi_pt_helper.c
+++ b/atapi_pt_helper/src/atapi_pt_helper.c
@@ -33,6 +33,7 @@
 #include <linux/bsg.h>
 #include <scsi/sg.h>
 #include <syslog.h>
+#include <stdbool.h>
 
 #include "atapi_pt_argo.h"
 
@@ -78,7 +79,7 @@ do {                                                               \
 #define XEN_ARGO_ROUNDUP(a) roundup((a), XEN_ARGO_MSG_SLOT_SIZE)
 
 #define ARGO_ATAPI_PT_RING_SIZE \
-  (XEN_ARGO_ROUNDUP((((4096)*64) - sizeof(xen_argo_ring_t)-XEN_ARGO_ROUNDUP(1))))
+  (XEN_ARGO_ROUNDUP((((4096)*64) - ARGO_RING_OVERHEAD)))
 
 #define MAX_ARGO_MSG_SIZE (ARGO_ATAPI_PT_RING_SIZE)
 

--- a/qmp_helper/src/qmp_helper.c
+++ b/qmp_helper/src/qmp_helper.c
@@ -62,7 +62,7 @@ do {                                                                 \
 #define ARGO_QH_PORT 5100
 #define ARGO_CHARDRV_PORT 15100
 #define ARGO_CHARDRV_RING_SIZE \
-  (XEN_ARGO_ROUNDUP((((4096)*4) - sizeof(xen_argo_ring_t)-XEN_ARGO_ROUNDUP(1))))
+  (XEN_ARGO_ROUNDUP((((4096)*4) - ARGO_RING_OVERHEAD)))
 
 #define ARGO_CHARDRV_NAME  "[argo-chardrv]"
 


### PR DESCRIPTION
This PR works in conjuction with changes in xenclient-oe and linux-xen-argo repositories for OXT-1694.

- An include for `<stdbool.h>` is needed since it is no longer provided via transitivity
- `xen_argo_ring_t` is no longer visible to Linux userspace so the headroom left for ring header use is calculated without it. The method used here should be revisited with the interface provided to userspace by new Linux Argo driver. The value `(8 * XEN_ARGO_ROUNDUP(1))` leaves 3 slots of headroom over the prior value as a precaution in the absence of a method for sizing provided by the driver.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>