### PR TITLE
QMP timeout fixes

### DIFF
--- a/qmp_helper/src/qmp_helper.c
+++ b/qmp_helper/src/qmp_helper.c
@@ -173,7 +173,7 @@ static int qmph_unix_to_argo(struct qmp_helper_state *pqhs)
         return rcv;
     }
     else if (rcv == 0) {
-        QMPH_LOG("read(unix_fd) recieved EOF, telling qemu.\n");
+        QMPH_LOG("read(unix_fd) received EOF, telling qemu.\n");
         qmp_disconnect(pqhs);
         close(pqhs->unix_fd);
         pqhs->unix_fd = -1;


### PR DESCRIPTION
We have a 5 second timeout on HVM VM boot as libxl cannot connect to QMP in stubdom.  This patch series (in conjunction with a qemu patch in xenclient-oe) makes qmp_helper sent an initial connect message to keep in better sync with qemu in the stubdom.  This avoids the time out.

There are also two 5 second time outs on VM shutdown.  qemu in the stubdom has exited, so there is nothing to respond to qmp_helper's argo messages.  When that happens, have qmp_helper close the UNIX socket.  This short circuits the timeout to the same effect.

Also fix a log message typo.