### PR TITLE
xcpmd: Use vglass idl dbus signals

### DIFF
--- a/xcpmd/src/acpi-events.c
+++ b/xcpmd/src/acpi-events.c
@@ -272,7 +272,7 @@ static void handle_ac_adapter_event(uint32_t data) {
     struct ev_wrapper * e = acpi_event_table[EVENT_ON_AC];
 
     xenstore_write_int(data, XS_AC_ADAPTER_STATE_PATH);
-    notify_com_citrix_xenclient_xcpmd_ac_adapter_state_changed(xcdbus_conn, XCPMD_SERVICE, XCPMD_PATH);
+    notify_com_citrix_xenclient_xcpmd_ac_adapter_state_changed(xcdbus_conn, XCPMD_SERVICE, XCPMD_PATH, data == ACPI_AC_STATUS_ONLINE);
 
     switch(data) {
         case ACPI_AC_STATUS_OFFLINE:

--- a/xcpmd/src/battery.c
+++ b/xcpmd/src/battery.c
@@ -913,7 +913,7 @@ void update_batteries(void) {
     if ((old_array_size != new_array_size) || (memcmp(old_status, last_status, new_array_size * sizeof(struct battery_status)))) {
         //Here for compatibility--should eventually be removed
         xenstore_write("1", XS_BATTERY_STATUS_CHANGE_EVENT_PATH);
-        notify_com_citrix_xenclient_xcpmd_battery_status_changed(xcdbus_conn, XCPMD_SERVICE, XCPMD_PATH);
+        notify_com_citrix_xenclient_xcpmd_battery_status_changed(xcdbus_conn, XCPMD_SERVICE, XCPMD_PATH, get_overall_battery_percentage());
     }
 
     if (present_batteries_changed) {


### PR DESCRIPTION
Update for the new vglass idl which pass the battery percentage in
battery_status_changed, and the ac adapter state in
ac_adapter_state_changed.  This lets vglass update it's banner battery
information.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

Depends on https://github.com/OpenXT/idl/pull/43