### PR TITLE
xcpmd: Send battery changed when the percent changes

### DIFF
--- a/xcpmd/src/battery.c
+++ b/xcpmd/src/battery.c
@@ -911,9 +911,16 @@ void update_batteries(void) {
     }
 
     if ((old_array_size != new_array_size) || (memcmp(old_status, last_status, new_array_size * sizeof(struct battery_status)))) {
-        //Here for compatibility--should eventually be removed
-        xenstore_write("1", XS_BATTERY_STATUS_CHANGE_EVENT_PATH);
-        notify_com_citrix_xenclient_xcpmd_battery_status_changed(xcdbus_conn, XCPMD_SERVICE, XCPMD_PATH, get_overall_battery_percentage());
+        static int previous_percent;
+        int current_percent = get_overall_battery_percentage();
+
+        if (current_percent != previous_percent)  {
+            previous_percent = current_percent;
+            //Here for compatibility--should eventually be removed
+            xenstore_write("1", XS_BATTERY_STATUS_CHANGE_EVENT_PATH);
+            notify_com_citrix_xenclient_xcpmd_battery_status_changed(
+                xcdbus_conn, XCPMD_SERVICE, XCPMD_PATH, current_percent);
+        }
     }
 
     if (present_batteries_changed) {


### PR DESCRIPTION
xcpmd polls the battery every 4 seconds.  When running on battery,
*something* will have changed in that time.  Even on AC, the values have
typically changes such that xcpmd is sending the DBus notification.

However, the only thing that the UI cares about is the battery
percentage.  So check the percentage and only send it if has changed.
This avoids xcpmd sending a message, but it also removes multiple DBus
queries by the UI for more information.

It's a little bit of a micro optimization, but it is also easy.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>