### PR TITLE
xcpmd: Fix double closedir()

### DIFF
--- a/xcpmd/src/battery.c
+++ b/xcpmd/src/battery.c
@@ -572,7 +572,6 @@ int update_battery_status(unsigned int battery_index) {
         status.remaining_capacity = status.energy_now;
     }
 
-    closedir(battery_dir);
     memcpy(&last_status[battery_index], &status, sizeof(struct battery_status));
 #ifdef XCPMD_DEBUG
     print_battery_status(battery_index);


### PR DESCRIPTION
I had the fixup for this locally, but I pushed a stale branch in https://github.com/OpenXT/xctools/pull/70 . Sorry about that.

commit a7fab046cb3c "xcpmd: unify update_battery_info/status" broke xcpmd startup.  It aborts with:

double free or corruption (top)

When update_battery_info() and update_battery_status() were merged, the two closedir() calls were retained.  Only one call is correct. Remove the second that leads to the abort().

Fixed: a7fab046cb3c "xcpmd: unify update_battery_info/status"
Signed-off-by: Jason Andryuk <jandryuk@gmail.com>