### PR TITLE
xcpmd: Install default.rules

### DIFF
--- a/xcpmd/src/Makefile.am
+++ b/xcpmd/src/Makefile.am
@@ -56,6 +56,9 @@ xcpmd_LDADD = \
 	$(LIBXCXENSTORE_LIBS)
 xcpmd_LDFLAGS = -rdynamic
 
+xcpmddir = $(datadir)/xcpmd
+xcpmd_DATA = default.rules
+
 #
 # RPC generated stubs.
 #


### PR DESCRIPTION
We have the rules in the source tree, but we need to install them into the system at /usr/share/xcpmd/default.rules so they can be used at runtime.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

This makes the rules from https://github.com/OpenXT/xctools/pull/74 functional.